### PR TITLE
add development / tox to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ Out[4]: {'name': '2CPU/8GB/60GB (Falcon S 202202)', 'redis_size': '1024'}
 
 ```
 
+## Development
+
+To run the unit tests you can us `tox`:
+```
+tox
+```
+
 ## Related projects
 
 - The official [Hypernode API PHP Client](https://github.com/byteinternet/hypernode-api-php)


### PR DESCRIPTION
Looks like:
```bash
$ tox
py3.7 installed: attrs==22.1.0,black==22.10.0,certifi==2022.9.24,charset-normalizer==2.1.1,click==8.1.3,execnet==1.9.0,idna==3.4,importlib-metadata==5.0.0,iniconfig==1.1.1,mypy-extensions==0.4.3,packaging==21.3,pathspec==0.10.1,platformdirs==2.5.2,pluggy==1.0.0,py==1.11.0,pycodestyle==2.9.1,pyparsing==3.0.9,pytest==7.1.3,pytest-forked==1.4.0,pytest-xdist==2.5.0,requests==2.28.1,tomli==2.0.1,typed-ast==1.5.4,typing_extensions==4.4.0,urllib3==1.26.12,zipp==3.9.0
py3.7 run-test-pre: PYTHONHASHSEED='1231230123'
py3.7 run-test: commands[0] | pytest --numprocesses=auto --quiet tests/
bringing up nodes...
...                                                                                                                                                                                                                                     [100%]
3 passed in 0.74s
py3.7 run-test: commands[1] | black --check .
All done!
7 files would be left unchanged.
py3.7 run-test: commands[2] | pycodestyle --config=pycodestyle.ini --exclude=venv,.tox
py3.8 create: /home/youruser/code/projects/hypernode-api-python/.tox/py3.8
SKIPPED: InterpreterNotFound: python3.8
___________________________________________________________________________________________________________________ summary ___________________________________________________________________________________________________________________
  py3.7: commands succeeded
SKIPPED:  py3.8: InterpreterNotFound: python3.8
  congratulations :)
```