### PR TITLE
move various methods to the open source client

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,24 +27,44 @@ pip install -e git+https://github.com/byteinternet/hypernode-api-python.git@mast
 ```
 Of course you might want to put that in a `requirements.txt` file in your project instead of installing it manually.
 
+###  Performing API calls
+
 Then to use the API client you can test out an example request in your Python repl:
-```bash
-[1]: from hypernode_api_python.client import HypernodeAPIPython
+```python
+from hypernode_api_python.client import HypernodeAPIPython
 
-In [2]: client = HypernodeAPIPython(token='yoursecrettoken')
+client = HypernodeAPIPython(token='yoursecrettoken')
 
-In [3]: response = client.get_app_flavor('yourhypernodeappname')
+response = client.get_app_flavor('yourhypernodeappname')
 
-In [4]: response.json()
-Out[4]: {'name': '2CPU/8GB/60GB (Falcon S 202202)', 'redis_size': '1024'}
-
+response.json()
+{'name': '2CPU/8GB/60GB (Falcon S 202202)', 'redis_size': '1024'}
 ```
+
+Using the Hypernode-API you can automate all kinds of cool things like configuring settings:
+```python
+client.set_app_setting('yourhypernodeappname', 'php_version', '8.1').json()
+{'name': 'yourhypernodeappname', 'type': 'persistent', 'php_version': '8.1', ...}
+```
+
+To even performing acts of cloud automation, like scaling to the first next larger plan:
+```python
+client.xgrade(
+    'yourhypernodeappname',
+      data={
+          'product': client.get_next_best_plan_for_app_or_404(
+              'yourhypernodeappname'
+          ).json()['code']
+      }
+)
+```
+
 
 ## Development
 
-To run the unit tests you can us `tox`:
-```
-tox
+To run the unit tests you can use `tox`:
+```bash
+tox -r
 ```
 
 ## Related projects

--- a/hypernode_api_python/client.py
+++ b/hypernode_api_python/client.py
@@ -1,28 +1,630 @@
 from requests import Session
 
+DEFAULT_USER_AGENT = "hypernode-api-python"
 HYPERNODE_API_URL = "https://api.hypernode.com"
-
+HYPERNODE_API_ADDON_SLA_LIST_ENDPOINT = "/v2/addon/slas/"
+HYPERNODE_API_APP_CHECK_PAYMENT_INFORMATION = "/v2/app/{}/check-payment-information/"
+HYPERNODE_API_APP_CONFIGURATION_ENDPOINT = "/v2/configuration/"
+HYPERNODE_API_APP_DETAIL_ENDPOINT = "/v2/app/{}/?destroyed=false"
+HYPERNODE_API_APP_DETAIL_WITH_ADDONS_ENDPOINT = "/v2/app/{}/with_addons?destroyed=false"
+HYPERNODE_API_APP_EAV_DESCRIPTION_ENDPOINT = "/v2/app/eav_descriptions/"
 HYPERNODE_API_APP_FLAVOR_ENDPOINT = "/v2/app/{}/flavor/"
+HYPERNODE_API_APP_NEXT_BEST_PLAN_ENDPOINT = "/v2/app/{}/next_best_plan/"
+HYPERNODE_API_APP_PRODUCT_LIST_ENDPOINT = "/v2/product/app/{}/"
+HYPERNODE_API_APP_XGRADE_CHECK_ENDPOINT = "/v2/app/xgrade/{}/check/{}/"
+HYPERNODE_API_APP_XGRADE_ENDPOINT = "/v2/app/xgrade/{}/"
+HYPERNODE_API_BACKUPS_ENDPOINT = "/v2/app/{}/backup/"
+HYPERNODE_API_PRODUCT_APP_DETAIL_ENDPOINT = "/v2/product/app/{}/current/"
+HYPERNODE_API_PRODUCT_LIST_ENDPOINT = "/v2/product/"
+HYPERNODE_API_PRODUCT_PRICE_DETAIL_ENDPOINT = "/v2/product/{}/with_price/"
+HYPERNODE_API_VALIDATE_APP_NAME_ENDPOINT = "/v2/app/name/validate/"
+HYPERNODE_API_WHITELIST_ENDPOINT = "/v2/whitelist/{}/"
+HYPERNODE_API_APP_ORDER_ENDPOINT = "/v2/app/order/"
 
 
 class HypernodeAPIPython:
-    def __init__(self, token, api_url=None):
+    def __init__(self, token, api_url=None, user_agent=None):
+        """
+        The official Hypernode API client for Python
+
+        :param str token: The API token you're using to talk to the API
+        Check out /etc/hypernode/hypernode_api_token on the Hypernode to
+        find your token.
+        :param str api_url: The URL of the API. Leave None if you wish
+        to use the 'real' Hypernode API. For local development you might
+        want to override this (if you want to talk to a different API, or
+        no real API at all).
+        :param str user_agent: The user agent to use when doing the API
+        requests. If you leave this None it will default to DEFAULT_USER_AGENT,
+        but you may want to enter the name of your application here.
+        """
         self.session = Session()
         self.token = token
         self.api_url = api_url if api_url else HYPERNODE_API_URL
         self.authorization_header = "Token {}".format(self.token)
+        self.user_agent = user_agent if user_agent else DEFAULT_USER_AGENT
 
     def requests(self, method, path, *args, **kwargs):
+        """
+        Some default requests settings. You can override this entire
+        method if you wish to set some different defaults.
+        """
         kwargs.setdefault("headers", {}).update(
             {
                 "Accept": "application/json",
                 "Authorization": self.authorization_header,
                 "Accept-Language": "en-US",
+                "User-Agent": self.user_agent,
             }
         )
         return self.session.request(
             method, HYPERNODE_API_URL.rstrip("/") + path, *args, **kwargs
         )
 
+    def _get_app_endpoint_or_404(self, app_name, endpoint, error_to_raise=None):
+        """
+        Get the app endpoint and return the response, but if the status_code is
+        404 then raise the specified exception. Raises RuntimeError by default
+        but if you're using this in for example a Django application you might
+        want to raise a django.http.response.Http404 instead.
+
+        :param str app_name: The name of the app to get the endpoint of
+        :param str endpoint: The endpoint to get
+        :param obj error_to_raise: What error to raise if the name is not
+        valid or available. By default, this will be RuntimeError.
+        :return obj response: The request response object
+        """
+        error_to_raise = error_to_raise if error_to_raise else RuntimeError
+        response = self.requests("GET", endpoint.format(app_name))
+
+        if response.status_code == 404:
+            raise error_to_raise("App {} not found.".format(app_name))
+        return response
+
+    def get_app_info_or_404(self, app_name):
+        """
+        Get information about the specified app. Raises if the status returns 404.
+        Example:
+        >    client.get_app_info_or_404('yourhypernodeappname').json()
+        >    {
+        >        'account_user':
+        >            {
+        >                'email': 'email@example.com',
+        >                'first_name': 'Firstname',
+        >                'id': 0,
+        >                'last_name': 'Lastname',
+        >                'username': 'email@example.com'
+        >            },
+        >        'destroyed': False,
+        >        'domainname': 'yourhypernodeappname.hypernode.io',
+        >        'flavor': {'name': '2CPU/8GB/60GB (Falcon S 202202)', 'redis_size': '1024'},
+        >        'in_production': True,
+        >        'ip': '1.2.3.4',
+        >        'mysql_version': '8.0',
+        >        'name': 'yourhypernodeappname',
+        >        'type': 'persistent',
+        >        ...
+        >    }
+
+        :param str app_name: The name of the app to get information about
+        :return obj response: The request response object
+        """
+        return self._get_app_endpoint_or_404(
+            app_name, HYPERNODE_API_APP_DETAIL_ENDPOINT
+        )
+
+    def get_next_best_plan_for_app_or_404(self, app_name):
+        """
+        Ask the API for what the next plan would be for this app
+        if it was looking to upgrade. In case you want to implement
+        some sort of auto-scaling you need a way to query the API for
+        the product code (and product name) of the plan next in line.
+        For example, if you are on the Falcon S, doing this API call
+        would return you information about the Falcon M. If the information
+        for the specified app_name can not be queried due to a 404, this
+        method will raise.
+        Example:
+        >    client.get_next_best_plan_for_app_or_404('yourhypernodeappname').json()
+        >    {'name': 'Falcon M', 'code': 'FALCON_M_202203'}
+
+        :param str app_name: The name of the app to get the next best plan for
+        :return obj response: The request response object
+        """
+        return self._get_app_endpoint_or_404(
+            app_name, HYPERNODE_API_APP_NEXT_BEST_PLAN_ENDPOINT
+        )
+
+    def validate_app_name(self, app_name, error_to_raise=None):
+        """
+        Check if an app name is valid and available. Before you create
+        a new Hypernode you could check if the name is available.
+
+        :param str app_name: The name of the app to check for availability
+        :param obj error_to_raise: What error to raise if the name is not
+        valid or available. By default, this will be RuntimeError.
+        :return NoneType None: If it's valid, we don't raise, but we don't
+        return anything either.
+        """
+        error_to_raise = error_to_raise if error_to_raise else RuntimeError
+        response = self.requests(
+            "GET", HYPERNODE_API_VALIDATE_APP_NAME_ENDPOINT, params={"name": app_name}
+        )
+        if response.content and response.content.decode() != "[]":
+            data = response.json()
+            if isinstance(data, dict):
+                raise error_to_raise(data["errors"])
+            raise error_to_raise(data)
+
     def get_app_flavor(self, app_name):
+        """
+        Get the flavor of an app
+        Example:
+        >    client.get_app_flavor('yourhypernodeappname').json()
+        >    {'name': '2CPU/8GB/60GB (Falcon S 202202)', 'redis_size': '1024'}
+
+        :param str app_name: The name of the app to get the flavor for
+        :return obj response: The request response object
+        """
         return self.requests("GET", HYPERNODE_API_APP_FLAVOR_ENDPOINT.format(app_name))
+
+    def get_slas(self):
+        """
+        List the available SLAs
+        Example:
+        >    client.get_slas().json()
+        >    [{'billing_period': 1,
+        >    'billing_period_unit': 'month',
+        >    'code': 'sla-standard',
+        >    'id': 123,
+        >    'name': 'SLA Standard',
+        >    'price': 1234},
+        >    ..]
+
+        :return obj response: The request response object
+        """
+        return self.requests("GET", HYPERNODE_API_ADDON_SLA_LIST_ENDPOINT)
+
+    def get_available_backups_for_app(self, app_name):
+        """
+        Lists the available backups for the specified app
+        Example:
+        >    client.get_available_backups_for_app('yourhypernodeappname').json()
+        >    {
+        >        'count': 11,
+        >        'next': None,
+        >        'previous': None,
+        >        'results': [
+        >            {
+        >                'backup_created_at': '2022-09-30T13:26:01+02:00',
+        >                'backup_id': '12341234-1234-1234-1234-123412341234',
+        >                'expired_at': '2022-10-28T13:26:01+02:00',
+        >                'type': 'periodic'
+        >            },
+        >            ...
+        >        ]
+        >    }
+
+        :param str app_name: The app to look up the available backups for
+        :return obj response: The request response object
+        """
+        return self.requests("GET", HYPERNODE_API_BACKUPS_ENDPOINT.format(app_name))
+
+    def get_app_eav_description(self):
+        """
+        List all the available EAV settings that are available. These are
+        the same settings as you'd be able to configure using the command-line
+        tool on the Hypernode itself (hypernode-systemctl settings).
+        Example:
+        >    client.get_app_eav_description().json()
+        >    {
+        >        'varnish_enabled': [True, False],
+        >        'php_version': ['8.0', '8.1'],
+        >        ...
+        >    }
+
+        :return obj response: The request response object
+        """
+        return self.requests("GET", HYPERNODE_API_APP_EAV_DESCRIPTION_ENDPOINT)
+
+    def set_app_setting(self, app_name, attribute, value):
+        """
+        Update a setting on the app, like the PHP or MySQL version. See
+        get_app_eav_description for all possible values. This is similar
+        to hypernode-systemctl settings.
+        Example:
+        >    client.get_app_eav_description().json()
+        >    {
+        >        'varnish_enabled': [True, False],
+        >        'php_version': ['8.0', '8.1'],
+        >        ...
+        >    }
+
+        :param str app_name: The app to configure the setting for
+        :param str attribute: The setting to configure, like 'php_version'
+        :param str || bool value: The value to set it to, like '8.1'
+        :return obj response: The request response object
+        """
+        data = {attribute: value}
+        return self.requests(
+            "PATCH", HYPERNODE_API_APP_DETAIL_ENDPOINT.format(app_name), data=data
+        )
+
+    def get_app_configurations(self):
+        """
+        List all the available app configurations. These are the available
+        configurations you can select when ordering a new Hypernode. For example
+        if you'd use the Magento 2 app configuration you'd get a certain PHP version
+        and specific Magento 2 NGINX configurations.
+        Example:
+        >    client.get_app_configurations().json()
+        >    {
+        >        'count': 2,
+        >        'next': None,
+        >        'previous': None,
+        >        'results': [
+        >            {
+        >                'allow_preinstall': True,
+        >                'composer_version': '2.x',
+        >                'name': 'Akeneo 4.0',
+        >                'elasticsearch_enabled': True,
+        >                'elasticsearch_version': '7.x',
+        >                ...
+        >            },
+        >            ...
+        >        ]
+        >    }
+
+        :return obj response: The request response object
+        """
+        return self.requests("GET", HYPERNODE_API_APP_CONFIGURATION_ENDPOINT)
+
+    def get_product_info_with_price(self, product_code, error_to_raise=None):
+        """
+        Get information about a specific product
+        :param str product_code: The code of the product to get information of
+        :param obj error_to_raise: What error to raise if the product does not
+        exist. By default this will be RuntimeError.
+        Example:
+        >    client.get_product_info_with_price('MAGG201909').json()
+        >    {
+        >        'backups_enabled': True,
+        >        'code': 'FALCON_S_202203',
+        >        'is_development': False,
+        >        'name': 'Grow',
+        >        'price': 1234,
+        >        'provider': 'combell',
+        >        'related_product': {
+        >            'backups_enabled': True,
+        >            'code': 'FALCON_S_202203DEV',
+        >            'is_development': True,
+        >            'name': 'Grow Development',
+        >            'price': 4321,
+        >            'provider': 'combell',
+        >            'storage_size_in_gb': 44,
+        >            'supports_sla': False,
+        >            'varnish_supported': False
+        >        },
+        >        'storage_size_in_gb': 44,
+        >        'supports_sla': True,
+        >        'varnish_supported': False
+        >    }
+
+        :return obj response: The request response object
+        """
+        error_to_raise = error_to_raise if error_to_raise else RuntimeError
+        response = self.requests(
+            "GET", HYPERNODE_API_PRODUCT_PRICE_DETAIL_ENDPOINT.format(product_code)
+        )
+        if response.status_code == 404:
+            raise error_to_raise
+        return response
+
+    def get_whitelist_options(self, app_name):
+        """
+        Get whitelist options for app. Retrieve the options for specifying
+        whitelist information for this Hypernode. See hypernode-systemctl
+        for an implementation example of how this can be used to configure
+        the firewall using the Hypernode API.
+        Example:
+        >    client.get_whitelist_options('yourhypernodeappname').json())
+        >    {'actions':
+        >        {'POST':
+        >            {'description':
+        >                {
+        >                    'label': 'Description',
+        >                    'read_only': False,
+        >                    'required': False,
+        >                    'type': 'string'
+        >                },
+        >                'ip': {
+        >                    'label': 'Ip',
+        >                    'read_only': False,
+        >                    'required': True,
+        >                    'type': 'string'
+        >                },
+        >                'type': {
+        >                    'choices': [
+        >                        {
+        >                            'display_name': 'waf',
+        >                            'value': 'waf'
+        >                        },
+        >                        {
+        >                            'display_name': 'database',
+        >                            'value': 'database'
+        >                        },
+        >                        {
+        >                            'display_name': 'ftp',
+        >                            'value': 'ftp'
+        >                        }
+        >                    ],
+        >                    'label': 'Type',
+        >                    'read_only': False,
+        >                    'required': True,
+        >                    'type': 'choice'
+        >                }
+        >            }
+        >        },
+        >        'description': '',
+        >        'name': 'Whitelist',
+        >        'parses': [
+        >            'application/json',
+        >            'application/x-www-form-urlencoded',
+        >            'multipart/form-data'
+        >        ],
+        >        'renders': ['application/json']
+        >    }
+
+        :param str app_name: The name of the app to get the whitelist information for
+        :return obj response: The request response object
+        """
+        return self.requests(
+            "OPTIONS", HYPERNODE_API_WHITELIST_ENDPOINT.format(app_name)
+        )
+
+    def get_whitelist_rules(self, app_name, filter_data=None):
+        """
+        Get the whitelist rules currently configured for the specified app
+        Example:
+        >    client.get_whitelist_rules('yourhypernodeappname').json())
+        >    [
+        >        {
+        >            'created': '2022-10-23T14:49:06Z',
+        >            'description': '',
+        >            'domainname': 'yourhypernodeappname.hypernode.io',
+        >            'id': 1234,
+        >            'ip': '1.2.3.4',
+        >            'type': 'waf'
+        >        },
+        >        ...
+        >    ]
+
+        :param str app_name: The name of the Hypernode you want to get the
+        currently configured whitelist information for.
+        :param dict filter_data: Filter the results based on this filter
+        An example filter to specify could be: {'type': 'waf'}
+        :return obj response: The request response object
+        """
+        filter_data = filter_data or {}
+        return self.requests(
+            "GET", HYPERNODE_API_WHITELIST_ENDPOINT.format(app_name), filter_data
+        )
+
+    def get_current_product_for_app(self, app_name):
+        """
+        Retrieve information about the product the specified App is currently on.
+        Example:
+        >    client.get_current_product_for_app('yourhypernodeappname').json()
+        >    {
+        >        'backups_enabled': True,
+        >        'code': 'FALCON_S_202203',
+        >        'flavor': {
+        >            'name': '2CPU/8GB/60GB (Falcon S 202202)', 'redis_size': '1024'
+        >        },
+        >        'is_active': True,
+        >        'is_development': False,
+        >        'name': 'Falcon S',
+        >        'price': 1234,
+        >        'provider_flavors': [
+        >            {
+        >                'disk_size_in_gb': 1234,
+        >                'exact_disk_size_in_kb': 1234,
+        >                'inodes': 1234,
+        >                'provider': {
+        >                    'display_name': 'Combell OpenStack',
+        >                    'name': 'combell'
+        >                },
+        >                'ram_in_mb': 8192,
+        >                'vcpus': 2
+        >            }
+        >        ],
+        >        'related_product': {
+        >            'backups_enabled': True,
+        >            'code': 'FALCON_S_202203DEV',
+        >            'flavor': {
+        >                'name': '2CPU/8GB/60GB (Falcon S 202202)',
+        >                'redis_size': '1024'
+        >            },
+        >            'is_active': True,
+        >            'is_development': True,
+        >            'name': 'Falcon S Development',
+        >            'price': 1234,
+        >            'provider_flavors': [
+        >                {
+        >                    'disk_size_in_gb': 1234,
+        >                    'exact_disk_size_in_kb': 1234,
+        >                    'inodes': 1234,
+        >                    'provider': {
+        >                        'display_name': 'Combell '
+        >                                        'OpenStack',
+        >                        'name': 'combell'
+        >                    },
+        >                    'ram_in_mb': 8192,
+        >                    'vcpus': 2
+        >                }
+        >            ],
+        >            'supports_sla': False,
+        >            'varnish_supported': True
+        >        },
+        >        'supports_sla': True,
+        >        'varnish_supported': True
+        >    }
+
+        :param str app_name: The name of the Hypernode to retrieve the product
+        information for.
+        :return obj response: The request response object
+        """
+        return self.requests(
+            "GET", HYPERNODE_API_PRODUCT_APP_DETAIL_ENDPOINT.format(app_name)
+        )
+
+    def check_payment_information_for_app(self, app_name):
+        """
+        Get the payment information that is currently configured for this Hypernode
+        Example:
+        >    client.check_payment_information_for_app('yourhypernodeappname').json()
+        >    {
+        >        'has_valid_vat_number': True,
+        >        'has_valid_payment_method': True,
+        >    }
+
+        :param str app_name: The Hypernode to check the payment information for
+        :return obj response: The request response object
+        """
+        return self.requests(
+            "GET", HYPERNODE_API_APP_CHECK_PAYMENT_INFORMATION.format(app_name)
+        )
+
+    def get_active_products(self):
+        """
+        Retrieve the list of products that are currently available. You can
+        change the plan of your Hypernode to these products. Doing so would
+        start a migration and change your subscription to the specified plan.
+        Example:
+        >    client.get_active_products().json()
+        >    [
+        >        {'backups_enabled': True,
+        >         'code': 'FALCON_XS_202203',
+        >         'flavor': {
+        >             'name': '2CPU/4GB/60GB (Falcon XS 202202)', 'redis_size': '768'
+        >         },
+        >         'is_active': True,
+        >         'is_development': False,
+        >         'name': 'Falcon XS',
+        >         'price': 1234,
+        >         'provider_flavors': [
+        >             {'disk_size_in_gb': 1234,
+        >              'exact_disk_size_in_kb': 1234,
+        >              'inodes': 1234,
+        >              'provider': {
+        >                  'display_name': 'Combell OpenStack',
+        >                  'name': 'combell'
+        >              },
+        >              'ram_in_mb': 4096,
+        >              'vcpus': 2
+        >              }
+        >         ],
+        >         'related_product': {
+        >             'backups_enabled': True,
+        >             'code': 'FALCON_XS_202203DEV',
+        >             'flavor': {
+        >                 'name': '2CPU/4GB/60GB (Falcon XS 202202)',
+        >                 'redis_size': '768'
+        >             },
+        >             'is_active': True,
+        >             'is_development': True,
+        >             'name': 'Falcon XS Development',
+        >             'price': 1234,
+        >             'provider_flavors': [
+        >                 {
+        >                     'disk_size_in_gb': 1234,
+        >                     'exact_disk_size_in_kb': 1234,
+        >                     'inodes': 1234,
+        >                     'provider': {
+        >                         'display_name': 'Combell '
+        >                                         'OpenStack',
+        >                         'name': 'combell'
+        >                     },
+        >                     'ram_in_mb': 4096,
+        >                     'vcpus': 2
+        >                 }
+        >             ],
+        >             'supports_sla': False,
+        >             'varnish_supported': False
+        >         },
+        >         'supports_sla': True,
+        >         'varnish_supported': False
+        >         },
+        >        ...
+        >    ]
+
+        :return obj response: The request response object
+        """
+        return self.requests("GET", HYPERNODE_API_PRODUCT_LIST_ENDPOINT)
+
+    def check_xgrade(self, app_name, product_code):
+        """
+        Checks if the Hypernode 'is going to fit' on the new product. Retrieves some
+        information about what a plan change to the specified product would look like for
+        the specified app. If it does not fit because the disk space currently in use is too
+        high, then we can find out here. Also, whether the IP will change, or if the volume
+        would entail a rsync migration or a more sophisticated volume swap cloud action which
+        would mean a significantly shorter migration time (depending on how much space is used).
+        Example:
+        >    client.check_xgrade('yourhypernodeappname', 'FALCON_S_202203').json()
+        >    {
+        >        'has_valid_vat_number': True,
+        >        'has_valid_payment_method': True,
+        >        'will_change_ip': False,
+        >        'will_do_volswap': True,
+        >        'will_disk_fit': True
+        >    }
+
+        :param str app_name: The name of the Hypernode to check the xgrade for
+        :param str product_code: The destination product we're checking. So if we'd xgrade
+        to this product, what would that mean? The response will tell us.
+        :return obj response: The request response object
+        """
+        return self.requests(
+            "GET",
+            HYPERNODE_API_APP_XGRADE_CHECK_ENDPOINT.format(app_name, product_code),
+        )
+
+    def xgrade(self, app_name, data):
+        """
+        Change the product of a Hypernode to a different plan. This will initiate
+        a migration of the Hypernode to a larger or smaller Hypernode, depending on
+        what product you specify. Progress of the migration can be tracked on the
+        hypernode by running hypernode-log (or getting that information from the API
+        directly as well). This API call does not result any output, on success the
+        response.text will be an empty string and the status_code will be 200.
+
+        :param str app_name: The name of the Hypernode to change the product of
+        :param dict data: Data regarding what product the Hypernode should be changed
+        to. An example could be: {'product': 'FALCON_S_202203'}. You can also specify a
+        scheduled_at time in case you want to perform the migration at a scheduled
+        moment. That could look something like this:
+        {'product': 'FALCON_S_202203', 'scheduled_at': '2022-11-25T01:00:00+03:00'}
+        :return obj response: The request response object
+        """
+        return self.requests(
+            "PATCH", HYPERNODE_API_APP_XGRADE_ENDPOINT.format(app_name), data=data
+        )
+
+    def order_hypernode(self, data):
+        """
+        Orders a new Hypernode. Note that you can not do this with the API permissions
+        of the API token of a Hypernode. If you wish to programmatically order Hypernodes
+        please contact support@hypernode.com, and we'll set up an API token with appropriate
+        permissions for you. Also, if this is something you're actively working on, we'd love
+        to hear about your use-case.
+
+        :param dict data: Data regarding the Hypernode that should be newly created
+        This should be something like:
+        {
+            'app_name': 'mynewhypernodeappnameofmax16chars',
+            'product': 'FALCON_S_202203',
+            'initial_app_configuration': 'magento_2',
+        }
+        :return obj response: The request response object
+        """
+        return self.requests("POST", HYPERNODE_API_APP_ORDER_ENDPOINT, data=data)

--- a/tests/client/test_check_payment_information_for_app.py
+++ b/tests/client/test_check_payment_information_for_app.py
@@ -1,0 +1,38 @@
+from unittest.mock import Mock
+
+from tests.testcase import TestCase
+from hypernode_api_python.client import (
+    HypernodeAPIPython,
+    HYPERNODE_API_APP_CHECK_PAYMENT_INFORMATION,
+)
+
+
+class TestCheckPaymentInformationForApp(TestCase):
+    def setUp(self):
+        self.client = HypernodeAPIPython(token="mytoken")
+        self.mock_request = Mock()
+        self.client.requests = self.mock_request
+
+    def test_check_app_payment_info_endpoint_is_correct(self):
+        self.assertEqual(
+            "/v2/app/{}/check-payment-information/",
+            HYPERNODE_API_APP_CHECK_PAYMENT_INFORMATION,
+        )
+
+    def test_calls_check_app_payment_info_endpoint_properly(self):
+        self.client.check_payment_information_for_app("yourhypernodeappname")
+
+        self.mock_request.assert_called_once_with(
+            "GET",
+            HYPERNODE_API_APP_CHECK_PAYMENT_INFORMATION.format("yourhypernodeappname"),
+        )
+
+    def test_returns_check_app_payment_info_data(self):
+        response = Mock()
+        response.status_code = 200
+        self.mock_request.return_value = response
+
+        self.assertEqual(
+            self.client.check_payment_information_for_app("yourhypernodeappname"),
+            self.mock_request.return_value,
+        )

--- a/tests/client/test_check_xgrade.py
+++ b/tests/client/test_check_xgrade.py
@@ -1,0 +1,36 @@
+from unittest.mock import Mock
+
+from tests.testcase import TestCase
+from hypernode_api_python.client import (
+    HypernodeAPIPython,
+    HYPERNODE_API_APP_XGRADE_CHECK_ENDPOINT,
+)
+
+
+class TestCheckXGrade(TestCase):
+    def setUp(self):
+        self.client = HypernodeAPIPython(token="mytoken")
+        self.mock_request = Mock()
+        self.client.requests = self.mock_request
+
+    def test_xgrade_check_endpoint_is_correct(self):
+        self.assertEqual(
+            "/v2/app/xgrade/{}/check/{}/", HYPERNODE_API_APP_XGRADE_CHECK_ENDPOINT
+        )
+
+    def test_calls_xgrade_check_endpoint_properly(self):
+        self.client.check_xgrade("yourhypernodeappname", "MAGG201908")
+
+        self.mock_request.assert_called_once_with(
+            "GET", "/v2/app/xgrade/yourhypernodeappname/check/MAGG201908/"
+        )
+
+    def test_returns_check_xgrade_data(self):
+        response = Mock()
+        response.status_code = 200
+        self.mock_request.return_value = response
+
+        self.assertEqual(
+            self.client.check_xgrade("yourhypernodeappname", "MAGG201908"),
+            self.mock_request.return_value,
+        )

--- a/tests/client/test_get_active_products.py
+++ b/tests/client/test_get_active_products.py
@@ -1,0 +1,31 @@
+from unittest.mock import Mock
+
+from tests.testcase import TestCase
+from hypernode_api_python.client import (
+    HypernodeAPIPython,
+    HYPERNODE_API_PRODUCT_LIST_ENDPOINT,
+)
+
+
+class TestGetActiveProducts(TestCase):
+    def setUp(self):
+        self.client = HypernodeAPIPython(token="mytoken")
+        self.mock_request = Mock()
+        self.client.requests = self.mock_request
+
+    def test_product_endpoint_is_correct(self):
+        self.assertEqual("/v2/product/", HYPERNODE_API_PRODUCT_LIST_ENDPOINT)
+
+    def test_calls_product_list_endpoint_properly(self):
+        self.client.get_active_products()
+
+        self.mock_request.assert_called_once_with("GET", "/v2/product/")
+
+    def test_returns_product_data(self):
+        response = Mock()
+        response.status_code = 200
+        self.mock_request.return_value = response
+
+        self.assertEqual(
+            self.client.get_active_products(), self.mock_request.return_value
+        )

--- a/tests/client/test_get_app_configuration.py
+++ b/tests/client/test_get_app_configuration.py
@@ -1,0 +1,33 @@
+from unittest.mock import Mock
+
+from tests.testcase import TestCase
+from hypernode_api_python.client import (
+    HypernodeAPIPython,
+    HYPERNODE_API_APP_CONFIGURATION_ENDPOINT,
+)
+
+
+class TestGetAppConfiguration(TestCase):
+    def setUp(self):
+        self.client = HypernodeAPIPython(token="mytoken")
+        self.mock_request = Mock()
+        self.client.requests = self.mock_request
+
+    def test_api_app_configuration_list_endpoint_is_correct(self):
+        self.assertEqual("/v2/configuration/", HYPERNODE_API_APP_CONFIGURATION_ENDPOINT)
+
+    def test_calls_app_configuration_endpoint_properly(self):
+        self.client.get_app_configurations()
+
+        self.mock_request.assert_called_once_with(
+            "GET", HYPERNODE_API_APP_CONFIGURATION_ENDPOINT
+        )
+
+    def test_returns_app_configuration_data(self):
+        response = Mock()
+        response.status_code = 200
+        self.mock_request.return_value = response
+
+        self.assertEqual(
+            self.client.get_app_configurations(), self.mock_request.return_value
+        )

--- a/tests/client/test_get_app_eav_description.py
+++ b/tests/client/test_get_app_eav_description.py
@@ -1,0 +1,27 @@
+from unittest.mock import Mock
+
+from tests.testcase import TestCase
+from hypernode_api_python.client import (
+    HypernodeAPIPython,
+)
+
+
+class TestGetAppDescription(TestCase):
+    def setUp(self):
+        self.client = HypernodeAPIPython(token="mytoken")
+        self.mock_request = Mock()
+        self.client.requests = self.mock_request
+
+    def test_calls_hypernode_api_app_eav_description_endpoint(self):
+        self.client.get_app_eav_description()
+
+        self.mock_request.assert_called_once_with("GET", "/v2/app/eav_descriptions/")
+
+    def test_returns_response_json_if_hypernode_api_returns_description(self):
+        response = Mock()
+        response.status_code = 200
+        self.mock_request.return_value = response
+
+        ret = self.client.get_app_eav_description()
+
+        self.assertEqual(ret, self.mock_request.return_value)

--- a/tests/client/test_get_app_endpoint_or_404.py
+++ b/tests/client/test_get_app_endpoint_or_404.py
@@ -1,0 +1,45 @@
+from unittest.mock import Mock
+
+from tests.testcase import TestCase
+from hypernode_api_python.client import (
+    HypernodeAPIPython,
+)
+
+
+class TestGetAppEndpointOr404(TestCase):
+    def setUp(self):
+        self.client = HypernodeAPIPython(token="mytoken")
+        self.mock_request = Mock()
+        self.client.requests = self.mock_request
+
+    def test_get_app_endpoint_or_404_gets_endpoint(self):
+        self.client._get_app_endpoint_or_404("yourhypernodeappname", "/v2/app/{}/")
+
+        self.mock_request.assert_called_once_with(
+            "GET", "/v2/app/yourhypernodeappname/"
+        )
+
+    def test_raises_runtime_error_if_hypernode_api_returns_404(self):
+        response = Mock()
+        response.status_code = 404
+        self.mock_request.return_value = response
+
+        with self.assertRaises(RuntimeError):
+            self.client._get_app_endpoint_or_404("yourhypernodeappname", "/v2/app/{}/")
+
+    def test_raises_specified_error_if_hypernode_api_returns_404(self):
+        response = Mock()
+        response.status_code = 404
+        self.mock_request.return_value = response
+
+        with self.assertRaises(OSError):
+            self.client._get_app_endpoint_or_404(
+                "yourhypernodeappname", "/v2/app/{}/", error_to_raise=OSError
+            )
+
+    def test_get_app_endpoint_or_404_returns_response(self):
+        ret = self.client._get_app_endpoint_or_404(
+            "yourhypernodeappname", "/v2/app/{}/"
+        )
+
+        self.assertEqual(ret, self.mock_request.return_value)

--- a/tests/client/test_get_app_info_or_404.py
+++ b/tests/client/test_get_app_info_or_404.py
@@ -1,0 +1,37 @@
+from unittest.mock import Mock
+
+from tests.testcase import TestCase
+from hypernode_api_python.client import (
+    HypernodeAPIPython,
+)
+
+
+class TestGetAppInfoOr404(TestCase):
+    def setUp(self):
+        self.client = HypernodeAPIPython(token="mytoken")
+        self.mock_request = Mock()
+        self.client.requests = self.mock_request
+
+    def test_calls_hypernode_api_app_endpoint_with_app_name(self):
+        self.client.get_app_info_or_404("yourhypernodeappname")
+
+        self.mock_request.assert_called_once_with(
+            "GET", "/v2/app/yourhypernodeappname/?destroyed=false"
+        )
+
+    def test_raises_if_hypernode_api_returns_404(self):
+        response = Mock()
+        response.status_code = 404
+        self.mock_request.return_value = response
+
+        with self.assertRaises(RuntimeError):
+            self.client.get_app_info_or_404("yourhypernodeappname")
+
+    def test_returns_response_json_if_hypernode_api_returns_app_info(self):
+        response = Mock()
+        response.status_code = 200
+        self.mock_request.return_value = response
+
+        ret = self.client.get_app_info_or_404("yourhypernodeappname")
+
+        self.assertEqual(ret, self.mock_request.return_value)

--- a/tests/client/test_get_available_backups_for_app.py
+++ b/tests/client/test_get_available_backups_for_app.py
@@ -1,0 +1,30 @@
+from unittest.mock import Mock
+
+from tests.testcase import TestCase
+from hypernode_api_python.client import (
+    HypernodeAPIPython,
+    HYPERNODE_API_BACKUPS_ENDPOINT,
+)
+
+
+class TestGetAvailableBackupsForApp(TestCase):
+    def setUp(self):
+        self.client = HypernodeAPIPython(token="mytoken")
+        self.mock_request = Mock()
+        self.client.requests = self.mock_request
+
+    def test_api_available_backups_endpoint_is_correct(self):
+        self.assertEqual("/v2/app/{}/backup/", HYPERNODE_API_BACKUPS_ENDPOINT)
+
+    def test_calls_available_backups_endpoint_properly(self):
+        self.client.get_available_backups_for_app("myhypernodeappname")
+
+        self.mock_request.assert_called_once_with(
+            "GET", "/v2/app/myhypernodeappname/backup/"
+        )
+
+    def test_returns_available_backups_data(self):
+        self.assertEqual(
+            self.client.get_available_backups_for_app("myhypernodeappname"),
+            self.mock_request.return_value,
+        )

--- a/tests/client/test_get_current_product_for_app.py
+++ b/tests/client/test_get_current_product_for_app.py
@@ -1,0 +1,36 @@
+from unittest.mock import Mock
+
+from tests.testcase import TestCase
+from hypernode_api_python.client import (
+    HypernodeAPIPython,
+    HYPERNODE_API_PRODUCT_APP_DETAIL_ENDPOINT,
+)
+
+
+class TestGetCurrentProductForApp(TestCase):
+    def setUp(self):
+        self.client = HypernodeAPIPython(token="mytoken")
+        self.mock_request = Mock()
+        self.client.requests = self.mock_request
+
+    def test_product_app_endpoint_is_correct(self):
+        self.assertEqual(
+            "/v2/product/app/{}/current/", HYPERNODE_API_PRODUCT_APP_DETAIL_ENDPOINT
+        )
+
+    def test_calls_product_app_detail_endpoint_properly(self):
+        self.client.get_current_product_for_app("yourhypernodeappname")
+
+        self.mock_request.assert_called_once_with(
+            "GET", "/v2/product/app/yourhypernodeappname/current/"
+        )
+
+    def test_returns_product_data(self):
+        response = Mock()
+        response.status_code = 200
+        self.mock_request.return_value = response
+
+        self.assertEqual(
+            self.client.get_current_product_for_app("yourhypernodeappname"),
+            self.mock_request.return_value,
+        )

--- a/tests/client/test_get_next_best_plan_for_app_or_404.py
+++ b/tests/client/test_get_next_best_plan_for_app_or_404.py
@@ -1,0 +1,37 @@
+from unittest.mock import Mock
+
+from tests.testcase import TestCase
+from hypernode_api_python.client import (
+    HypernodeAPIPython,
+)
+
+
+class TestGetNextBestPlanForAppOr404(TestCase):
+    def setUp(self):
+        self.client = HypernodeAPIPython(token="mytoken")
+        self.mock_request = Mock()
+        self.client.requests = self.mock_request
+
+    def test_calls_hypernode_api_app_next_best_plan_endpoint_with_app_name(self):
+        self.client.get_next_best_plan_for_app_or_404("yourhypernodeappname")
+
+        self.mock_request.assert_called_once_with(
+            "GET", "/v2/app/yourhypernodeappname/next_best_plan/"
+        )
+
+    def test_raises_if_hypernode_api_returns_404_for_next_best_plan_app(self):
+        response = Mock()
+        response.status_code = 404
+        self.mock_request.return_value = response
+
+        with self.assertRaises(RuntimeError):
+            self.client.get_next_best_plan_for_app_or_404("yourhypernodeappname")
+
+    def test_returns_response_json_if_hypernode_api_returns_next_best_plan(self):
+        response = Mock()
+        response.status_code = 200
+        self.mock_request.return_value = response
+
+        ret = self.client.get_next_best_plan_for_app_or_404("yourhypernodeappname")
+
+        self.assertEqual(ret, self.mock_request.return_value)

--- a/tests/client/test_get_product_info_with_price.py
+++ b/tests/client/test_get_product_info_with_price.py
@@ -1,0 +1,38 @@
+from unittest.mock import Mock
+
+from tests.testcase import TestCase
+from hypernode_api_python.client import (
+    HypernodeAPIPython,
+    HYPERNODE_API_PRODUCT_PRICE_DETAIL_ENDPOINT,
+)
+
+
+class TestGetProductInfoWithPrice(TestCase):
+    def setUp(self):
+        self.mock_request = Mock()
+        self.client = HypernodeAPIPython(token="mytoken")
+        self.client.requests = self.mock_request
+
+    def test_calls_hypernode_api_product_endpoint_with_correct_parameters(self):
+        self.client.get_product_info_with_price("MAGS")
+
+        self.mock_request.assert_called_once_with(
+            "GET", HYPERNODE_API_PRODUCT_PRICE_DETAIL_ENDPOINT.format("MAGS")
+        )
+
+    def test_returns_json_result(self):
+        ret = self.client.get_product_info_with_price("MAGS")
+
+        self.assertEqual(ret, self.mock_request.return_value)
+
+    def test_raises_runtime_error_when_request_returns_404(self):
+        self.mock_request.return_value = Mock(status_code=404)
+
+        with self.assertRaises(RuntimeError):
+            self.client.get_product_info_with_price("MAGS")
+
+    def test_raises_specified_error_when_request_returns_404(self):
+        self.mock_request.return_value = Mock(status_code=404)
+
+        with self.assertRaises(OSError):
+            self.client.get_product_info_with_price("MAGS", error_to_raise=OSError)

--- a/tests/client/test_get_slas.py
+++ b/tests/client/test_get_slas.py
@@ -1,0 +1,26 @@
+from unittest.mock import Mock
+
+from tests.testcase import TestCase
+from hypernode_api_python.client import (
+    HypernodeAPIPython,
+    HYPERNODE_API_ADDON_SLA_LIST_ENDPOINT,
+)
+
+
+class TestGetSlas(TestCase):
+    def setUp(self):
+        self.mock_request = Mock()
+        self.client = HypernodeAPIPython(token="mytoken")
+        self.client.requests = self.mock_request
+
+    def test_calls_hypernode_api_endpoint_with_correct_parameters(self):
+        self.client.get_slas()
+
+        self.mock_request.assert_called_once_with(
+            "GET", HYPERNODE_API_ADDON_SLA_LIST_ENDPOINT
+        )
+
+    def test_returns_json_result(self):
+        ret = self.client.get_slas()
+
+        self.assertEqual(ret, self.mock_request.return_value)

--- a/tests/client/test_get_whitelist_options.py
+++ b/tests/client/test_get_whitelist_options.py
@@ -1,0 +1,28 @@
+from unittest.mock import Mock
+
+from tests.testcase import TestCase
+from hypernode_api_python.client import (
+    HypernodeAPIPython,
+    HYPERNODE_API_WHITELIST_ENDPOINT,
+)
+
+
+class TestGetWhitelistOptions(TestCase):
+    def setUp(self):
+        self.mock_request = Mock()
+        self.client = HypernodeAPIPython(token="mytoken")
+        self.client.requests = self.mock_request
+
+    def test_calls_hypernode_api_whitelist_options_endpoint_with_correct_parameters(
+        self,
+    ):
+        self.client.get_whitelist_options("yourhypernodeappname")
+
+        self.mock_request.assert_called_once_with(
+            "OPTIONS", HYPERNODE_API_WHITELIST_ENDPOINT.format("yourhypernodeappname")
+        )
+
+    def test_returns_json_result_for_hypernode_api_whitelist_options(self):
+        ret = self.client.get_whitelist_options("yourhypernodeappname")
+
+        self.assertEqual(ret, self.mock_request.return_value)

--- a/tests/client/test_get_whitelist_rules.py
+++ b/tests/client/test_get_whitelist_rules.py
@@ -1,0 +1,41 @@
+from unittest.mock import Mock
+
+from tests.testcase import TestCase
+from hypernode_api_python.client import (
+    HypernodeAPIPython,
+    HYPERNODE_API_WHITELIST_ENDPOINT,
+)
+
+
+class TestGetWhitelistRules(TestCase):
+    def setUp(self):
+        self.mock_request = Mock()
+        self.client = HypernodeAPIPython(token="mytoken")
+        self.client.requests = self.mock_request
+
+    def test_calls_hypernode_api_whitelist_rules_endpoint_with_correct_parameters(
+        self,
+    ):
+        self.client.get_whitelist_rules("yourhypernodeappname")
+
+        self.mock_request.assert_called_once_with(
+            "GET", HYPERNODE_API_WHITELIST_ENDPOINT.format("yourhypernodeappname"), {}
+        )
+
+    def test_calls_hypernode_api_whitelist_rules_endpoint_with_correct_parameters_if_filter_specified(
+        self,
+    ):
+        self.client.get_whitelist_rules(
+            "yourhypernodeappname", filter_data={"type": "waf"}
+        )
+
+        self.mock_request.assert_called_once_with(
+            "GET",
+            HYPERNODE_API_WHITELIST_ENDPOINT.format("yourhypernodeappname"),
+            {"type": "waf"},
+        )
+
+    def test_returns_json_result_for_hypernode_api_whitelist_rules(self):
+        ret = self.client.get_whitelist_rules("yourhypernodeappname")
+
+        self.assertEqual(ret, self.mock_request.return_value)

--- a/tests/client/test_order_hypernode.py
+++ b/tests/client/test_order_hypernode.py
@@ -1,0 +1,36 @@
+from unittest.mock import Mock
+
+from tests.testcase import TestCase
+from hypernode_api_python.client import (
+    HypernodeAPIPython,
+    HYPERNODE_API_APP_ORDER_ENDPOINT,
+)
+
+
+class TestOrderHypernode(TestCase):
+    def setUp(self):
+        self.client = HypernodeAPIPython(token="mytoken")
+        self.mock_request = Mock()
+        self.client.requests = self.mock_request
+
+    def test_order_hypernode_endpoint_is_correct(self):
+        self.assertEqual("/v2/app/order/", HYPERNODE_API_APP_ORDER_ENDPOINT)
+
+    def test_calls_order_hypernode_endpoint_properly(self):
+        data = {
+            "app_name": "mynewhypernodeappnameofmax16chars",
+            "product": "FALCON_S_202203",
+            "initial_app_configuration": "magento_2",
+        }
+        self.client.order_hypernode(data)
+
+        self.mock_request.assert_called_once_with("POST", "/v2/app/order/", data=data)
+
+    def test_returns_hypernode_data(self):
+        response = Mock()
+        response.status_code = 200
+        self.mock_request.return_value = response
+
+        self.assertEqual(
+            self.client.order_hypernode({}), self.mock_request.return_value
+        )

--- a/tests/client/test_set_app_setting.py
+++ b/tests/client/test_set_app_setting.py
@@ -1,0 +1,37 @@
+from unittest.mock import Mock
+
+from tests.testcase import TestCase
+from hypernode_api_python.client import (
+    HypernodeAPIPython,
+    HYPERNODE_API_APP_DETAIL_ENDPOINT,
+)
+
+
+class TestSetAppSetting(TestCase):
+    def setUp(self):
+        self.client = HypernodeAPIPython(token="mytoken")
+        self.mock_request = Mock()
+        self.client.requests = self.mock_request
+
+    def test_set_app_setting_endpoint_is_correct(self):
+        self.assertEqual(
+            "/v2/app/{}/?destroyed=false", HYPERNODE_API_APP_DETAIL_ENDPOINT
+        )
+
+    def test_calls_set_app_setting_endpoint_properly(self):
+        self.client.set_app_setting("yourhypernodeappname", "php_version", "8.1")
+
+        expected_data = {"php_version": "8.1"}
+        self.mock_request.assert_called_once_with(
+            "PATCH", "/v2/app/yourhypernodeappname/?destroyed=false", data=expected_data
+        )
+
+    def test_returns_set_app_setting_data(self):
+        response = Mock()
+        response.status_code = 200
+        self.mock_request.return_value = response
+
+        self.assertEqual(
+            self.client.set_app_setting("yourhypernodeappname", "php_version", "8.1"),
+            self.mock_request.return_value,
+        )

--- a/tests/client/test_validate_app_name.py
+++ b/tests/client/test_validate_app_name.py
@@ -1,0 +1,68 @@
+from unittest.mock import Mock
+
+from tests.testcase import TestCase
+from hypernode_api_python.client import (
+    HypernodeAPIPython,
+    HYPERNODE_API_VALIDATE_APP_NAME_ENDPOINT,
+)
+
+
+class TestValidateAppName(TestCase):
+    def setUp(self):
+        self.mock_request = Mock()
+        self.client = HypernodeAPIPython(token="mytoken")
+        self.client.requests = self.mock_request
+
+    def test_hypernode_api_validate_app_name_endpoint_is_correct(self):
+        self.assertEqual(
+            HYPERNODE_API_VALIDATE_APP_NAME_ENDPOINT, "/v2/app/name/validate/"
+        )
+
+    def test_calls_validate_appname_endpoint_with_correct_parameters(self):
+        response = Mock()
+        response.content = ""
+        self.mock_request.return_value = response
+
+        self.client.validate_app_name("yourhypernodeappname")
+
+        self.mock_request.assert_called_once_with(
+            "GET",
+            HYPERNODE_API_VALIDATE_APP_NAME_ENDPOINT,
+            params={"name": "yourhypernodeappname"},
+        )
+
+    def test_raises_runtime_error_if_non_empty_response(self):
+        with self.assertRaises(RuntimeError):
+            self.client.validate_app_name("yourhypernodeappname")
+
+    def test_raises_specified_error_if_non_empty_response_and_error_to_raise_specified(
+        self,
+    ):
+        with self.assertRaises(OSError):
+            self.client.validate_app_name(
+                "yourhypernodeappname", error_to_raise=OSError
+            )
+
+    def test_raises_runtime_errors_if_json_result_is_dict(self):
+        response = Mock()
+        response.json.return_value = {"errors": ["fake-error"]}
+        self.mock_request.return_value = response
+
+        with self.assertRaises(RuntimeError):
+            self.client.validate_app_name("yourhypernodeappname")
+
+    def test_does_not_raise_runtime_error_if_no_content_in_response(self):
+        response = Mock()
+        response.content = None
+        self.mock_request.return_value = response
+
+        # Should not raise
+        self.client.validate_app_name("yourhypernodeappname")
+
+    def test_does_not_raise_runtime_error_if_empty_list_in_response(self):
+        response = Mock()
+        response.content.decode.return_value = "[]"
+        self.mock_request.return_value = response
+
+        # Should not raise
+        self.client.validate_app_name("yourhypernodeappname")

--- a/tests/client/test_xgrade.py
+++ b/tests/client/test_xgrade.py
@@ -1,0 +1,35 @@
+from unittest.mock import Mock
+
+from tests.testcase import TestCase
+from hypernode_api_python.client import (
+    HypernodeAPIPython,
+    HYPERNODE_API_APP_XGRADE_ENDPOINT,
+)
+
+
+class TestXGrade(TestCase):
+    def setUp(self):
+        self.client = HypernodeAPIPython(token="mytoken")
+        self.mock_request = Mock()
+        self.client.requests = self.mock_request
+
+    def test_xgrade_endpoint_is_correct(self):
+        self.assertEqual("/v2/app/xgrade/{}/", HYPERNODE_API_APP_XGRADE_ENDPOINT)
+
+    def test_calls_xgrade_endpoint_properly(self):
+        data = {"test": "data"}
+        self.client.xgrade("yourhypernodeappname", data)
+
+        self.mock_request.assert_called_once_with(
+            "PATCH", "/v2/app/xgrade/yourhypernodeappname/", data=data
+        )
+
+    def test_returns_xgrade_data(self):
+        response = Mock()
+        response.status_code = 200
+        self.mock_request.return_value = response
+
+        self.assertEqual(
+            self.client.xgrade("yourhypernodeappname", {}),
+            self.mock_request.return_value,
+        )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{3.7,3.8}
+envlist = py{3.7,3.8,3.9}
 skipsdist = True
 skip_missing_interpreters = True
 
@@ -8,6 +8,7 @@ skip_missing_interpreters = True
 basepython =
     py3.7: python3.7
     py3.8: python3.8
+    py3.9: python3.9
 
 deps = -rrequirements/development.txt
 


### PR DESCRIPTION
This commit moves these methods to the open source hypernode-api-python client:
```python
get_app_info_or_404
get_next_best_plan_for_app_or_404
validate_app_name
get_slas
get_available_backups_for_app
get_app_eav_description
set_app_settings
get_app_configurations
get_product_info_with_price
get_whitelist_options
get_whitelist_rules
get_current_product_for_app
check_payment_information_for_app
get_active_products
check_xgrade
xgrade
order_hypernode
```

There is some code in here that's slightly incongruent, but that's an artifact of where this came from. I added docstrings with usage examples and refactored out some of the django specific exceptions (Http404) and replaced those with RuntimeError so that the client doesn't make any assumptions about being ran in a Django application.