### PR TITLE
Add Destroy Brancher helper function

### DIFF
--- a/hypernode_api_python/client.py
+++ b/hypernode_api_python/client.py
@@ -10,6 +10,7 @@ HYPERNODE_API_APP_DETAIL_WITH_ADDONS_ENDPOINT = "/v2/app/{}/with_addons?destroye
 HYPERNODE_API_APP_EAV_DESCRIPTION_ENDPOINT = "/v2/app/eav_descriptions/"
 HYPERNODE_API_APP_FLAVOR_ENDPOINT = "/v2/app/{}/flavor/"
 HYPERNODE_API_APP_BRANCHER_ENDPOINT = "/v2/app/{}/brancher/"
+HYPERNODE_API_BRANCHER_ENDPOINT = "/v2/brancher/{}/"
 HYPERNODE_API_APP_NEXT_BEST_PLAN_ENDPOINT = "/v2/app/{}/next_best_plan/"
 HYPERNODE_API_APP_PRODUCT_LIST_ENDPOINT = "/v2/product/app/{}/"
 HYPERNODE_API_APP_XGRADE_CHECK_ENDPOINT = "/v2/app/xgrade/{}/check/{}/"
@@ -674,4 +675,15 @@ class HypernodeAPIPython:
         """
         return self.requests(
             "POST", HYPERNODE_API_APP_BRANCHER_ENDPOINT.format(app_name), data=data
+        )
+
+    def destroy_brancher(self, brancher_name):
+        """
+        Destroy an existing brancher node of your Hypernode.
+
+        :param str brancher_name: The name of the brancher node to destroy.
+        :return obj response: The request response object
+        """
+        return self.requests(
+            "DELETE", HYPERNODE_API_BRANCHER_ENDPOINT.format(brancher_name)
         )

--- a/tests/client/test_destroy_brancher.py
+++ b/tests/client/test_destroy_brancher.py
@@ -1,0 +1,35 @@
+from unittest import TestCase
+from unittest.mock import Mock
+
+from hypernode_api_python.client import (
+    HypernodeAPIPython,
+    HYPERNODE_API_BRANCHER_ENDPOINT,
+)
+
+
+class TestDestroyBrancher(TestCase):
+    def setUp(self):
+        self.client = HypernodeAPIPython(token="my_token")
+        self.mock_request = Mock()
+        self.client.requests = self.mock_request
+        self.brancher_name = "app-branchermobyname"
+
+    def test_brancher_endpoint_is_correct(self):
+        self.assertEqual("/v2/brancher/{}/", HYPERNODE_API_BRANCHER_ENDPOINT)
+
+    def test_calls_destroy_brancher_endpoint_properly(self):
+        self.client.destroy_brancher(self.brancher_name)
+
+        self.mock_request.assert_called_once_with(
+            "DELETE", HYPERNODE_API_BRANCHER_ENDPOINT.format(self.brancher_name)
+        )
+
+    def test_returns_destroy_brancher_data(self):
+        response = Mock()
+        response.status_code = 204
+        self.mock_request.return_value = response
+
+        self.assertEqual(
+            self.client.destroy_brancher(self.brancher_name),
+            self.mock_request.return_value,
+        )


### PR DESCRIPTION
Helper function for destroying a brancher. This method is responsible for destroying an existing brancher node of your Hypernode. It takes one argument, brancher_name, which is the name of the brancher node to destroy, and returns a request response object. This method will allow users to easily delete brancher nodes through your application's API.