### PR TITLE
use-new-brancher-app-endpoint

### DIFF
--- a/hypernode_api_python/client.py
+++ b/hypernode_api_python/client.py
@@ -9,7 +9,7 @@ HYPERNODE_API_APP_DETAIL_ENDPOINT = "/v2/app/{}/?destroyed=false"
 HYPERNODE_API_APP_DETAIL_WITH_ADDONS_ENDPOINT = "/v2/app/{}/with_addons?destroyed=false"
 HYPERNODE_API_APP_EAV_DESCRIPTION_ENDPOINT = "/v2/app/eav_descriptions/"
 HYPERNODE_API_APP_FLAVOR_ENDPOINT = "/v2/app/{}/flavor/"
-HYPERNODE_API_APP_BRANCHER_ENDPOINT = "/v2/app/{}/brancher/"
+HYPERNODE_API_BRANCHER_APP_ENDPOINT = "/v2/brancher/app/{}/"
 HYPERNODE_API_BRANCHER_ENDPOINT = "/v2/brancher/{}/"
 HYPERNODE_API_APP_NEXT_BEST_PLAN_ENDPOINT = "/v2/app/{}/next_best_plan/"
 HYPERNODE_API_APP_PRODUCT_LIST_ENDPOINT = "/v2/product/app/{}/"
@@ -663,7 +663,7 @@ class HypernodeAPIPython:
         :return obj response: The request response object
         """
         return self.requests(
-            "GET", HYPERNODE_API_APP_BRANCHER_ENDPOINT.format(app_name)
+            "GET", HYPERNODE_API_BRANCHER_APP_ENDPOINT.format(app_name)
         )
 
     def create_brancher(self, app_name, data):
@@ -676,7 +676,7 @@ class HypernodeAPIPython:
         :return obj response: The request response object
         """
         return self.requests(
-            "POST", HYPERNODE_API_APP_BRANCHER_ENDPOINT.format(app_name), data=data
+            "POST", HYPERNODE_API_BRANCHER_APP_ENDPOINT.format(app_name), data=data
         )
 
     def destroy_brancher(self, brancher_name):

--- a/tests/client/test_create_brancher.py
+++ b/tests/client/test_create_brancher.py
@@ -2,7 +2,7 @@ from unittest import TestCase
 from unittest.mock import Mock
 
 from hypernode_api_python.client import (
-    HYPERNODE_API_APP_BRANCHER_ENDPOINT,
+    HYPERNODE_API_BRANCHER_APP_ENDPOINT,
     HypernodeAPIPython,
 )
 
@@ -15,14 +15,14 @@ class TestCreateBrancher(TestCase):
         self.app_name = "my_app"
 
     def test_brancher_endpoint_is_correct(self):
-        self.assertEqual("/v2/app/{}/brancher/", HYPERNODE_API_APP_BRANCHER_ENDPOINT)
+        self.assertEqual("/v2/brancher/app/{}/", HYPERNODE_API_BRANCHER_APP_ENDPOINT)
 
     def test_calls_create_brancher_endpoint_properly(self):
         data = {"clear_services": ["mysql"]}
         self.client.create_brancher(self.app_name, data)
 
         self.mock_request.assert_called_once_with(
-            "POST", f"/v2/app/{self.app_name}/brancher/", data=data
+            "POST", f"/v2/brancher/app/{self.app_name}/", data=data
         )
 
     def test_returns_create_brancher_data(self):

--- a/tests/client/test_get_active_branchers.py
+++ b/tests/client/test_get_active_branchers.py
@@ -2,7 +2,7 @@ from unittest import TestCase
 from unittest.mock import Mock
 
 from hypernode_api_python.client import (
-    HYPERNODE_API_APP_BRANCHER_ENDPOINT,
+    HYPERNODE_API_BRANCHER_APP_ENDPOINT,
     HypernodeAPIPython,
 )
 
@@ -15,13 +15,13 @@ class TestGetActiveBranchers(TestCase):
         self.app_name = "my_app"
 
     def test_brancher_endpoint_is_correct(self):
-        self.assertEqual("/v2/app/{}/brancher/", HYPERNODE_API_APP_BRANCHER_ENDPOINT)
+        self.assertEqual("/v2/brancher/app/{}/", HYPERNODE_API_BRANCHER_APP_ENDPOINT)
 
     def test_calls_get_active_branchers_endpoint_properly(self):
         self.client.get_active_branchers(self.app_name)
 
         self.mock_request.assert_called_once_with(
-            "GET", f"/v2/app/{self.app_name}/brancher/"
+            "GET", f"/v2/brancher/app/{self.app_name}/"
         )
 
     def test_returns_active_branchers_data(self):


### PR DESCRIPTION
Change the create and list brancher endpoints to use the new url. This will make it much easier to identify what customers are still using the old endpoint based on the logs