### PR TITLE
add simple cli entrypoints for api functionality

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -18,6 +18,36 @@ pip install -r requirements/development.txt
 
 Each Hypernode has an API token associated with it, you can use that to talk to the API directly. You can find the token in `/etc/hypernode/hypernode_api_token`. For API tokens with special permissions please contact support@hypernode.com. Not all functionality in the API is currently generally available but if you'd like to start automating and have an interesting use-case we'd love to hear from you.
 
+## Using the library from the commandline
+
+In the `bin/` directory you'll find entry points to interact with the API directly from the commandline.
+
+See for example:
+```bash
+$ export PYTHONPATH=.
+
+$ ./bin/get_slas --help
+usage: get_slas [-h]
+
+List all available SLAs.
+
+Example:
+$ ./bin/get_slas
+[
+  {
+    "id": 123,
+    "code": "sla-standard",
+    "name": "SLA Standard",
+    "price": 1234,
+    "billing_period": 1,
+    "billing_period_unit": "month"
+  },
+  ...
+]
+
+optional arguments:
+  -h, --help  show this help message and exit
+```
 
 ### Installing the library in your project
 
@@ -56,7 +86,7 @@ client.set_app_setting('yourhypernodeappname', 'php_version', '8.1').json()
 {'name': 'yourhypernodeappname', 'type': 'persistent', 'php_version': '8.1', ...}
 ```
 
-To even performing acts of cloud automation, like scaling to the first next larger plan:
+You can even perform acts of cloud automation, like scaling to the first next larger plan:
 ```python
 client.xgrade(
     'yourhypernodeappname',

--- a/bin/block_attack
+++ b/bin/block_attack
@@ -1,0 +1,1 @@
+command

--- a/bin/check_payment_information_for_app
+++ b/bin/check_payment_information_for_app
@@ -1,0 +1,1 @@
+command

--- a/bin/check_xgrade
+++ b/bin/check_xgrade
@@ -1,0 +1,1 @@
+command

--- a/bin/command
+++ b/bin/command
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+import os
+import sys
+from hypernode_api_python import commands
+
+
+if __name__ == '__main__':
+    command = os.path.basename(__file__)
+
+    if hasattr(commands, command):
+        sys.exit(getattr(commands, command)() or 0)
+    else:
+        sys.stderr.write("Command '{}' not found in hypernode_api_python.commands\n".format(command))
+        sys.exit(1)

--- a/bin/create_brancher
+++ b/bin/create_brancher
@@ -1,0 +1,1 @@
+command

--- a/bin/destroy_brancher
+++ b/bin/destroy_brancher
@@ -1,0 +1,1 @@
+command

--- a/bin/get_active_branchers
+++ b/bin/get_active_branchers
@@ -1,0 +1,1 @@
+command

--- a/bin/get_active_products
+++ b/bin/get_active_products
@@ -1,0 +1,1 @@
+command

--- a/bin/get_app_configurations
+++ b/bin/get_app_configurations
@@ -1,0 +1,1 @@
+command

--- a/bin/get_app_flavor
+++ b/bin/get_app_flavor
@@ -1,0 +1,1 @@
+command

--- a/bin/get_app_info
+++ b/bin/get_app_info
@@ -1,0 +1,1 @@
+command

--- a/bin/get_available_backups_for_app
+++ b/bin/get_available_backups_for_app
@@ -1,0 +1,1 @@
+command

--- a/bin/get_block_attack_descriptions
+++ b/bin/get_block_attack_descriptions
@@ -1,0 +1,1 @@
+command

--- a/bin/get_cluster_relations
+++ b/bin/get_cluster_relations
@@ -1,0 +1,1 @@
+command

--- a/bin/get_current_product_for_app
+++ b/bin/get_current_product_for_app
@@ -1,0 +1,1 @@
+command

--- a/bin/get_eav_description
+++ b/bin/get_eav_description
@@ -1,0 +1,1 @@
+command

--- a/bin/get_flows
+++ b/bin/get_flows
@@ -1,0 +1,1 @@
+command

--- a/bin/get_next_best_plan_for_app
+++ b/bin/get_next_best_plan_for_app
@@ -1,0 +1,1 @@
+command

--- a/bin/get_product_info
+++ b/bin/get_product_info
@@ -1,0 +1,1 @@
+command

--- a/bin/get_sla
+++ b/bin/get_sla
@@ -1,0 +1,1 @@
+command

--- a/bin/get_slas
+++ b/bin/get_slas
@@ -1,0 +1,1 @@
+command

--- a/bin/get_whitelist_options
+++ b/bin/get_whitelist_options
@@ -1,0 +1,1 @@
+command

--- a/bin/get_whitelist_rules
+++ b/bin/get_whitelist_rules
@@ -1,0 +1,1 @@
+command

--- a/bin/validate_app_name
+++ b/bin/validate_app_name
@@ -1,0 +1,1 @@
+command

--- a/bin/xgrade
+++ b/bin/xgrade
@@ -1,0 +1,1 @@
+command

--- a/hypernode_api_python/client.py
+++ b/hypernode_api_python/client.py
@@ -840,7 +840,6 @@ class HypernodeAPIPython:
             "GET", HYPERNODE_API_BRANCHER_APP_ENDPOINT.format(app_name)
         )
 
-    # TODO: add entrypoint for this method in bin/ and commands.py
     def create_brancher(self, app_name, data):
         """
         Create a new branch (server replica) of your Hypernode.
@@ -854,7 +853,6 @@ class HypernodeAPIPython:
             "POST", HYPERNODE_API_BRANCHER_APP_ENDPOINT.format(app_name), data=data
         )
 
-    # TODO: add entrypoint for this method in bin/ and commands.py
     def destroy_brancher(self, brancher_name):
         """
         Destroy an existing brancher node of your Hypernode.

--- a/hypernode_api_python/client.py
+++ b/hypernode_api_python/client.py
@@ -648,7 +648,6 @@ class HypernodeAPIPython:
             "GET", HYPERNODE_API_PRODUCT_APP_DETAIL_ENDPOINT.format(app_name)
         )
 
-    # TODO: add entrypoint for this method in bin/ and commands.py
     def check_payment_information_for_app(self, app_name):
         """
         Get the payment information that is currently configured for this Hypernode
@@ -666,7 +665,6 @@ class HypernodeAPIPython:
             "GET", HYPERNODE_API_APP_CHECK_PAYMENT_INFORMATION.format(app_name)
         )
 
-    # TODO: add entrypoint for this method in bin/ and commands.py
     def get_active_products(self):
         """
         Retrieve the list of products that are currently available. You can

--- a/hypernode_api_python/client.py
+++ b/hypernode_api_python/client.py
@@ -331,6 +331,7 @@ class HypernodeAPIPython:
         """
         return self.requests("GET", HYPERNODE_API_APP_EAV_DESCRIPTION_ENDPOINT)
 
+    # TODO: add entrypoint for this method in bin/ and commands.py
     def set_app_setting(self, app_name, attribute, value):
         """
         Update a setting on the app, like the PHP or MySQL version. See
@@ -384,7 +385,7 @@ class HypernodeAPIPython:
         return self.requests("GET", HYPERNODE_API_APP_CONFIGURATION_ENDPOINT)
 
     def get_cluster_relations(self, app_name):
-        """ "
+        """
         List all relations for the specified app. This will return all the
         relations that are currently configured for the specified app.
 
@@ -579,6 +580,7 @@ class HypernodeAPIPython:
             "GET", HYPERNODE_API_WHITELIST_ENDPOINT.format(app_name), filter_data
         )
 
+    # TODO: add entrypoint for this method in bin/ and commands.py
     def get_current_product_for_app(self, app_name):
         """
         Retrieve information about the product the specified App is currently on.
@@ -647,6 +649,7 @@ class HypernodeAPIPython:
             "GET", HYPERNODE_API_PRODUCT_APP_DETAIL_ENDPOINT.format(app_name)
         )
 
+    # TODO: add entrypoint for this method in bin/ and commands.py
     def check_payment_information_for_app(self, app_name):
         """
         Get the payment information that is currently configured for this Hypernode
@@ -664,6 +667,7 @@ class HypernodeAPIPython:
             "GET", HYPERNODE_API_APP_CHECK_PAYMENT_INFORMATION.format(app_name)
         )
 
+    # TODO: add entrypoint for this method in bin/ and commands.py
     def get_active_products(self):
         """
         Retrieve the list of products that are currently available. You can
@@ -731,6 +735,7 @@ class HypernodeAPIPython:
         """
         return self.requests("GET", HYPERNODE_API_PRODUCT_LIST_ENDPOINT)
 
+    # TODO: add entrypoint for this method in bin/ and commands.py
     def check_xgrade(self, app_name, product_code):
         """
         Checks if the Hypernode 'is going to fit' on the new product. Retrieves some
@@ -759,6 +764,7 @@ class HypernodeAPIPython:
             HYPERNODE_API_APP_XGRADE_CHECK_ENDPOINT.format(app_name, product_code),
         )
 
+    # TODO: add entrypoint for this method in bin/ and commands.py
     def xgrade(self, app_name, data):
         """
         Change the product of a Hypernode to a different plan. This will initiate
@@ -780,6 +786,7 @@ class HypernodeAPIPython:
             "PATCH", HYPERNODE_API_APP_XGRADE_ENDPOINT.format(app_name), data=data
         )
 
+    # TODO: add entrypoint for this method in bin/ and commands.py
     def order_hypernode(self, data):
         """
         Orders a new Hypernode. Note that you can not do this with the API permissions
@@ -799,6 +806,7 @@ class HypernodeAPIPython:
         """
         return self.requests("POST", HYPERNODE_API_APP_ORDER_ENDPOINT, data=data)
 
+    # TODO: add entrypoint for this method in bin/ and commands.py
     def get_active_branchers(self, app_name):
         """
         List all active brancher nodes of your Hypernode.
@@ -838,6 +846,7 @@ class HypernodeAPIPython:
             "GET", HYPERNODE_API_BRANCHER_APP_ENDPOINT.format(app_name)
         )
 
+    # TODO: add entrypoint for this method in bin/ and commands.py
     def create_brancher(self, app_name, data):
         """
         Create a new branch (server replica) of your Hypernode.
@@ -851,6 +860,7 @@ class HypernodeAPIPython:
             "POST", HYPERNODE_API_BRANCHER_APP_ENDPOINT.format(app_name), data=data
         )
 
+    # TODO: add entrypoint for this method in bin/ and commands.py
     def destroy_brancher(self, brancher_name):
         """
         Destroy an existing brancher node of your Hypernode.

--- a/hypernode_api_python/client.py
+++ b/hypernode_api_python/client.py
@@ -580,7 +580,6 @@ class HypernodeAPIPython:
             "GET", HYPERNODE_API_WHITELIST_ENDPOINT.format(app_name), filter_data
         )
 
-    # TODO: add entrypoint for this method in bin/ and commands.py
     def get_current_product_for_app(self, app_name):
         """
         Retrieve information about the product the specified App is currently on.

--- a/hypernode_api_python/client.py
+++ b/hypernode_api_python/client.py
@@ -761,7 +761,6 @@ class HypernodeAPIPython:
             HYPERNODE_API_APP_XGRADE_CHECK_ENDPOINT.format(app_name, product_code),
         )
 
-    # TODO: add entrypoint for this method in bin/ and commands.py
     def xgrade(self, app_name, data):
         """
         Change the product of a Hypernode to a different plan. This will initiate

--- a/hypernode_api_python/client.py
+++ b/hypernode_api_python/client.py
@@ -732,7 +732,6 @@ class HypernodeAPIPython:
         """
         return self.requests("GET", HYPERNODE_API_PRODUCT_LIST_ENDPOINT)
 
-    # TODO: add entrypoint for this method in bin/ and commands.py
     def check_xgrade(self, app_name, product_code):
         """
         Checks if the Hypernode 'is going to fit' on the new product. Retrieves some
@@ -802,7 +801,6 @@ class HypernodeAPIPython:
         """
         return self.requests("POST", HYPERNODE_API_APP_ORDER_ENDPOINT, data=data)
 
-    # TODO: add entrypoint for this method in bin/ and commands.py
     def get_active_branchers(self, app_name):
         """
         List all active brancher nodes of your Hypernode.

--- a/hypernode_api_python/commands.py
+++ b/hypernode_api_python/commands.py
@@ -1,0 +1,479 @@
+import json
+from os import environ, EX_OK, EX_UNAVAILABLE
+from argparse import ArgumentParser, RawTextHelpFormatter
+from hypernode_api_python.client import HypernodeAPIPython
+
+
+def get_client():
+    """
+    Instantiates the HypernodeAPIPython client with the token from the environment.
+    :return obj HypernodeAPIPython: The instantiated client
+    """
+    api_token = environ.get("HYPERNODE_API_TOKEN")
+    if not api_token:
+        raise ValueError(
+            "HYPERNODE_API_TOKEN environment variable not set. "
+            "Try running `export HYPERNODE_API_TOKEN=yourapitoken`"
+        )
+    client = HypernodeAPIPython(environ["HYPERNODE_API_TOKEN"])
+    return client
+
+
+def get_app_name():
+    """
+    Gets the app name from the environment.
+    :return str app_name: The app name
+    """
+    app_name = environ.get("HYPERNODE_APP_NAME")
+    if not app_name:
+        raise ValueError(
+            "HYPERNODE_APP_NAME environment variable not set. "
+            "Try running `export HYPERNODE_APP_NAME=yourhypernodeappname`"
+        )
+    return app_name
+
+
+def print_response(response):
+    """
+    Pretty prints the JSON response.
+    :param obj response: The response object
+    :return NoneType None: None
+    """
+    print(json.dumps(response.json(), indent=2))
+
+
+def get_app_info(args=None):
+    parser = ArgumentParser(
+        description="""
+Get information about the Hypernode app.
+
+Example:
+$ ./bin/get_app_info
+{
+  "name": "yourhypernodeappname",
+  "type": "persistent",
+  "product": {
+    "code": "FALCON_M_202203",
+    "name": "Falcon M",
+    "backups_enabled": true,
+    "storage_size_in_gb": 75,
+    "price": 1234,
+    "is_development": false,
+    "provider": "combell",
+    "varnish_supported": true,
+    "supports_sla": true
+  },
+  "domainname": "yourhypernodeappname.hypernode.io",
+  ...
+}
+""",
+        formatter_class=RawTextHelpFormatter,
+    )
+    parser.parse_args(args=args)
+    client = get_client()
+    app_name = get_app_name()
+    print_response(client.get_app_info_or_404(app_name))
+
+
+def get_next_best_plan_for_app(args=None):
+    parser = ArgumentParser(
+        description="""
+Get the plan that is the first bigger plan than the current plan for this Hypernode.
+This is convenient for if you want to upgrade your Hypernode to a bigger plan using the
+xgrade feature and you need to know which plan to upgrade to.
+
+Example:
+$ ./bin/get_next_best_plan_for_app
+{
+  "code": "FALCON_L_202203",
+  "name": "Falcon L"
+}
+""",
+        formatter_class=RawTextHelpFormatter,
+    )
+    parser.parse_args(args=args)
+    client = get_client()
+    app_name = get_app_name()
+    print_response(client.get_next_best_plan_for_app_or_404(app_name))
+
+
+def validate_app_name(args=None):
+    parser = ArgumentParser(
+        description="""
+Check if the specified app_name is valid and available. An app name can not be
+registered if it's already taken. Also there are certain restrictions on the
+app name, like it can't contain certain characters or exceed a certain length.
+
+Examples:
+$ ./bin/validate_app_name hypernode
+App name 'hypernode' is valid.
+
+$ ./bin/validate_app_name hyper_node
+App name 'hyper_node' is invalid: ["This value can only contain non-capital letters 'a' through 'z' or digits 0 through 9."]
+""",
+        formatter_class=RawTextHelpFormatter,
+    )
+    parser.add_argument(
+        "app_name",
+        help="The app name to validate",
+    )
+    args = parser.parse_args(args=args)
+    client = get_client()
+    try:
+        client.validate_app_name(args.app_name)
+        print("App name '{}' is valid.".format(args.app_name))
+        exit(EX_OK)
+    except Exception as e:
+        print("App name '{}' is invalid: {}".format(args.app_name, e))
+        exit(EX_UNAVAILABLE)
+
+
+def get_app_flavor(args=None):
+    parser = ArgumentParser(
+        description="""
+Get the current flavor of the Hypernode app.
+
+Example:
+$ ./bin/get_app_flavor
+{
+  "name": "3CPU/16GB/80GB (Falcon M 202202)",
+  "redis_size": "2048"
+}
+""",
+        formatter_class=RawTextHelpFormatter,
+    )
+    parser.parse_args(args=args)
+    client = get_client()
+    app_name = get_app_name()
+    print_response(client.get_app_flavor(app_name))
+
+
+def get_flows(args=None):
+    parser = ArgumentParser(
+        description="""
+Llist the flows for the Hypernode app. This is a history of all the
+Hypernode automation jobs that have been ran for this Hypernode.
+
+Example:
+$ ./bin/get_flows
+{
+  "count": 36,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "uuid": "ad3b520e-a424-4bcb-a6fb-7d1fc055c3fa",
+      "state": "success",
+      "name": "create_backup",
+      "created_at": "2024-05-25T10:01:25Z",
+      "updated_at": "2024-05-25T10:01:57Z",
+      "progress": {
+        "running": [],
+        "total": 2,
+        "completed": 2
+      },
+      "logbook": "myhypernodeappname",
+      "tracker": {
+        "uuid": null,
+        "description": null
+      }
+    },
+    ...
+}
+""",
+        formatter_class=RawTextHelpFormatter,
+    )
+    parser.parse_args(args=args)
+    client = get_client()
+    app_name = get_app_name()
+    print_response(client.get_flows(app_name))
+
+
+def get_slas(args=None):
+    parser = ArgumentParser(
+        description="""
+List all available SLAs.
+
+Example:
+$ ./bin/get_slas
+[
+  {
+    "id": 123,
+    "code": "sla-standard",
+    "name": "SLA Standard",
+    "price": 1234,
+    "billing_period": 1,
+    "billing_period_unit": "month"
+  },
+  ...
+]
+""",
+        formatter_class=RawTextHelpFormatter,
+    )
+    parser.parse_args(args=args)
+    client = get_client()
+    print_response(client.get_slas())
+
+
+def get_sla(args=None):
+    parser = ArgumentParser(
+        description="""
+Get a specific SLA.
+
+$ ./bin/get_sla sla-standard
+{
+  "id": 123,
+  "code": "sla-standard",
+  "name": "SLA Standard",
+  "price": 1234,
+  "billing_period": 1,
+  "billing_period_unit": "month"
+}
+""",
+        formatter_class=RawTextHelpFormatter,
+    )
+    parser.add_argument("sla_code", help="The code of the SLA to get")
+    args = parser.parse_args(args=args)
+    client = get_client()
+    print_response(client.get_sla(args.sla_code))
+
+
+def get_available_backups_for_app(args=None):
+    parser = ArgumentParser(
+        description="""
+List the available backups for the Hypernode
+
+Example:
+$ ./bin/get_available_backups_for_app
+{
+  "count": 10,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "backup_created_at": "2024-05-02T12:00:33+02:00",
+      "type": "periodic",
+      "backup_id": "1169e792-8b05-449c-a7b1-7d52cf43153a",
+      "expired_at": "2024-05-30T12:00:33+02:00"
+    },
+    ...
+]
+""",
+        formatter_class=RawTextHelpFormatter,
+    )
+    parser.parse_args(args=args)
+    client = get_client()
+    app_name = get_app_name()
+    print_response(client.get_available_backups_for_app(app_name))
+
+
+def get_eav_description(args=None):
+    parser = ArgumentParser(
+        description="""
+List all available EAV settings and their descriptions.
+
+Example:
+$ ./bin/get_eav_description
+{
+  "supervisor_enabled": [
+    true,
+    false
+  ],
+  "redis_eviction_policy": [
+    "noeviction",
+    "allkeys-lru",
+    "allkeys-lfu",
+    "volatile-lru",
+    "volatile-lfu",
+    "allkeys-random",
+    "volatile-random",
+    "volatile-ttl"
+  ],
+  ...
+}
+""",
+        formatter_class=RawTextHelpFormatter,
+    )
+    parser.parse_args(args=args)
+    client = get_client()
+    print_response(client.get_app_eav_description())
+
+
+def get_app_configurations(args=None):
+    parser = ArgumentParser(
+        description="""
+List all the available configurations that can be selected when ordering a new Hypernode.
+
+Example:
+$ ./bin/get_app_configurations
+{
+  "count": 7,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "name": "Akeneo 6.0",
+      "configuration_id": "akeneo_6_0",
+      "php_version": "8.0",
+      "mysql_version": "8.0",
+      ...
+    },
+    ...
+}
+""",
+        formatter_class=RawTextHelpFormatter,
+    )
+    parser.parse_args(args=args)
+    client = get_client()
+    print_response(client.get_app_configurations())
+
+
+def get_cluster_relations(args=None):
+    parser = ArgumentParser(
+        description="""
+List all the cluster relations for the Hypernode.
+
+Example:
+$ ./bin/get_cluster_relations
+{
+  "parents": [
+    {
+      "id": 182,
+      "parent": "mytestappdb",
+      "child": "mytestappweb",
+      "relation_type": "mysql",
+      "cluster_description": null
+    },
+    {
+      "id": 180,
+      "parent": "mytestapp",
+      "child": "mytestappweb",
+      "relation_type": "loadbalancer",
+      "cluster_description": null
+    },
+    ...
+}
+""",
+        formatter_class=RawTextHelpFormatter,
+    )
+    parser.parse_args(args=args)
+    client = get_client()
+    app_name = get_app_name()
+    print_response(client.get_cluster_relations(app_name))
+
+
+def get_product_info(args=None):
+    parser = ArgumentParser(
+        description="""
+Gets the product info for the specified product
+
+$ ./bin/get_product_info FALCON_S_202203
+{
+  "code": "FALCON_S_202203",
+  "name": "Falcon S",
+  "backups_enabled": true,
+  "storage_size_in_gb": 57,
+  "price": 1234,
+  ...
+}
+""",
+        formatter_class=RawTextHelpFormatter,
+    )
+    parser.add_argument("product_code", help="The code of the product to get")
+    args = parser.parse_args(args=args)
+    client = get_client()
+    print_response(client.get_product_info_with_price(args.product_code))
+
+
+def get_block_attack_descriptions(args=None):
+    parser = ArgumentParser(
+        description="""
+List all attack blocking strategies and their descriptions.
+
+Example:
+$ ./bin/get_block_attack_descriptions
+{
+  "BlockSqliBruteForce": "Attempts to deploy NGINX rules to block suspected (blind) SQL injection attacks",
+  ...
+}
+""",
+        formatter_class=RawTextHelpFormatter,
+    )
+    parser.parse_args(args=args)
+    client = get_client()
+    print_response(client.get_block_attack_descriptions())
+
+
+def block_attack(args=None):
+    parser = ArgumentParser(
+        description="""
+Block a specific attack based on a pre-defined attack blocking strategy.
+
+$ ./bin/block_attack BlockSqliBruteForce
+A job to block the 'BlockSqliBruteForce' attack has been posted.
+""",
+        formatter_class=RawTextHelpFormatter,
+    )
+    client = get_client()
+    choices = client.get_block_attack_descriptions().json().keys()
+    parser.add_argument("attack_name", help="The attack to block", choices=choices)
+    args = parser.parse_args(args=args)
+    app_name = get_app_name()
+    output = client.block_attack(app_name, args.attack_name).content
+    if output:
+        print(output)
+    else:
+        print(
+            "A job to block the '{}' attack has been posted.".format(args.attack_name)
+        )
+
+
+def get_whitelist_options(args=None):
+    parser = ArgumentParser(
+        description="""
+List all available WAF whitelist options for the Hypernode.
+
+Example:
+$ ./bin/get_whitelist_options
+{
+  "name": "Whitelist",
+  "description": "",
+  "renders": [
+    "application/json"
+  ],
+  ...
+}
+""",
+        formatter_class=RawTextHelpFormatter,
+    )
+    parser.parse_args(args=args)
+    client = get_client()
+    app_name = get_app_name()
+    print_response(client.get_whitelist_options(app_name))
+
+
+def get_whitelist_rules(args=None):
+    parser = ArgumentParser(
+        description="""
+List all currently configured WAF whitelist rules for the Hypernode.
+
+Example:
+$ ./bin/get_whitelist_rules
+[
+  {
+    "id": 1234,
+    "created": "2024-05-25T13:39:48Z",
+    "domainname": "yourhypernodeappname.hypernode.io",
+    "ip": "1.2.3.4",
+    "type": "database",
+    "description": "my description"
+  },
+  ...
+]
+""",
+        formatter_class=RawTextHelpFormatter,
+    )
+    parser.parse_args(args=args)
+    client = get_client()
+    app_name = get_app_name()
+    print_response(client.get_whitelist_rules(app_name))

--- a/hypernode_api_python/commands.py
+++ b/hypernode_api_python/commands.py
@@ -588,3 +588,33 @@ $ ./bin/check_xgrade FALCON_L_202203
     args = parser.parse_args(args=args)
     app_name = get_app_name()
     print_response(client.check_xgrade(app_name, args.product_code))
+
+
+def xgrade(args=None):
+    parser = ArgumentParser(
+        description="""
+Change the plan of your Hypernode.
+
+Example:
+$ ./bin/xgrade FALCON_L_202203
+The job to xgrade Hypernode 'yourappname' to product 'FALCON_L_202203' has been posted
+""",
+        formatter_class=RawTextHelpFormatter,
+    )
+    client = get_client()
+    parser.add_argument(
+        "product_code",
+        help="The code of the product to check",
+        choices=[p["code"] for p in client.get_active_products().json()],
+    )
+    args = parser.parse_args(args=args)
+    app_name = get_app_name()
+    data = {"product": args.product_code}
+    output = client.xgrade(app_name, data=data).content
+    if output:
+        print(output)
+    else:
+        print(
+            "The job to xgrade Hypernode '{}' to product '{}' "
+            "has been posted".format(app_name, args.product_code)
+        )

--- a/hypernode_api_python/commands.py
+++ b/hypernode_api_python/commands.py
@@ -553,3 +553,30 @@ $ ./bin/get_active_products
     parser.parse_args(args=args)
     client = get_client()
     print_response(client.get_active_products())
+
+
+def check_xgrade(args=None):
+    parser = ArgumentParser(
+        description="""
+Verify that the specified app can be upgraded to the specified product.
+This checks if there is enough disk space available. The output will also
+show whether or not there will be an IP change and if a volume swap xgrade
+would be performed instead of an rsync xgrade.
+
+Example:
+$ ./bin/check_xgrade FALCON_L_202203
+{
+  "has_valid_vat_number": true,
+  "has_valid_payment_method": true,
+  "will_change_ip": false,
+  "will_do_volswap": false,
+  "will_disk_fit": true
+}
+""",
+        formatter_class=RawTextHelpFormatter,
+    )
+    parser.add_argument("product_code", help="The code of the product to check")
+    args = parser.parse_args(args=args)
+    client = get_client()
+    app_name = get_app_name()
+    print_response(client.check_xgrade(app_name, args.product_code))

--- a/hypernode_api_python/commands.py
+++ b/hypernode_api_python/commands.py
@@ -379,9 +379,13 @@ $ ./bin/get_product_info FALCON_S_202203
 """,
         formatter_class=RawTextHelpFormatter,
     )
-    parser.add_argument("product_code", help="The code of the product to get")
-    args = parser.parse_args(args=args)
     client = get_client()
+    parser.add_argument(
+        "product_code",
+        help="The code of the product to get",
+        choices=[p["code"] for p in client.get_active_products().json()],
+    )
+    args = parser.parse_args(args=args)
     print_response(client.get_product_info_with_price(args.product_code))
 
 
@@ -575,8 +579,12 @@ $ ./bin/check_xgrade FALCON_L_202203
 """,
         formatter_class=RawTextHelpFormatter,
     )
-    parser.add_argument("product_code", help="The code of the product to check")
-    args = parser.parse_args(args=args)
     client = get_client()
+    parser.add_argument(
+        "product_code",
+        help="The code of the product to check",
+        choices=[p["code"] for p in client.get_active_products().json()],
+    )
+    args = parser.parse_args(args=args)
     app_name = get_app_name()
     print_response(client.check_xgrade(app_name, args.product_code))

--- a/hypernode_api_python/commands.py
+++ b/hypernode_api_python/commands.py
@@ -618,3 +618,26 @@ The job to xgrade Hypernode 'yourappname' to product 'FALCON_L_202203' has been 
             "The job to xgrade Hypernode '{}' to product '{}' "
             "has been posted".format(app_name, args.product_code)
         )
+
+
+def get_active_branchers(args=None):
+    parser = ArgumentParser(
+        description="""
+List all active branchers
+
+Example:
+$ ./bin/get_active_branchers
+{
+  "monthly_total_time": 0,
+  "total_minutes_elapsed": 0,
+  "actual_monthly_total_cost": 0,
+  "monthly_total_cost": 0,
+  "branchers": []
+}
+""",
+        formatter_class=RawTextHelpFormatter,
+    )
+    parser.parse_args(args=args)
+    client = get_client()
+    app_name = get_app_name()
+    print_response(client.get_active_branchers(app_name))

--- a/hypernode_api_python/commands.py
+++ b/hypernode_api_python/commands.py
@@ -477,3 +477,34 @@ $ ./bin/get_whitelist_rules
     client = get_client()
     app_name = get_app_name()
     print_response(client.get_whitelist_rules(app_name))
+
+
+def get_current_product_for_app(args=None):
+    parser = ArgumentParser(
+        description="""
+Gets the current product for the specified app.
+
+Example:
+$ ./bin/get_current_product_for_app
+{
+  "code": "FALCON_M_202203",
+  "name": "Falcon M",
+  "backups_enabled": true,
+  "is_development": false,
+  "varnish_supported": true,
+  "supports_sla": true,
+  "provider_flavors": [
+    {
+      "vcpus": 3,
+      "ram_in_mb": 16384,
+      ...
+    },
+    ...
+}
+""",
+        formatter_class=RawTextHelpFormatter,
+    )
+    parser.parse_args(args=args)
+    client = get_client()
+    app_name = get_app_name()
+    print_response(client.get_current_product_for_app(app_name))

--- a/hypernode_api_python/commands.py
+++ b/hypernode_api_python/commands.py
@@ -641,3 +641,63 @@ $ ./bin/get_active_branchers
     client = get_client()
     app_name = get_app_name()
     print_response(client.get_active_branchers(app_name))
+
+
+def create_brancher(args=None):
+    parser = ArgumentParser(
+        description="""
+Create a Brancher Hypernode from the specified app.
+Outputs the app_info of the brancher to be created..
+
+Example:
+$ ./bin/create_brancher
+{
+  "name": "yourappname-ephoj82yb",
+  "parent": "yourappname",
+  "type": "brancher",
+  "product": "FALCON_M_202203",
+  "domainname": "yourappname-ephoj82yb.hypernode.io",
+  ...
+}
+""",
+        formatter_class=RawTextHelpFormatter,
+    )
+    parser.parse_args(args=args)
+    client = get_client()
+    app_name = get_app_name()
+    data = {}
+    print_response(client.create_brancher(app_name, data=data))
+
+
+def destroy_brancher(args=None):
+    parser = ArgumentParser(
+        description="""
+Destroy a Brancher Hypernode.
+
+Examples:
+$ ./bin/destroy_brancher yourbrancherappname-eph12345
+A job has been posted to cancel the 'yourbrancherappname-eph12345' brancher app.
+""",
+        formatter_class=RawTextHelpFormatter,
+    )
+    parser.add_argument(
+        "brancher_app_name",
+        help="The name of the brancher to destroy. See ./bin/get_active_branchers",
+    )
+    args = parser.parse_args(args=args)
+    client = get_client()
+    try:
+        client.destroy_brancher(args.brancher_app_name)
+        print(
+            "A job has been posted to cancel the '{}' brancher app.".format(
+                args.brancher_app_name
+            )
+        )
+        exit(EX_OK)
+    except Exception as e:
+        print(
+            "Brancher app '{}' failed to be cancelled: {}".format(
+                args.brancher_app_name, e
+            )
+        )
+        exit(EX_UNAVAILABLE)

--- a/hypernode_api_python/commands.py
+++ b/hypernode_api_python/commands.py
@@ -508,3 +508,48 @@ $ ./bin/get_current_product_for_app
     client = get_client()
     app_name = get_app_name()
     print_response(client.get_current_product_for_app(app_name))
+
+
+def check_payment_information_for_app(args=None):
+    parser = ArgumentParser(
+        description="""
+Shows the payment information for the specified app.
+
+Example:
+$ ./bin/check_payment_information_for_app
+{
+  "has_valid_vat_number": true,
+  "has_valid_payment_method": true
+}
+""",
+        formatter_class=RawTextHelpFormatter,
+    )
+    parser.parse_args(args=args)
+    client = get_client()
+    app_name = get_app_name()
+    print_response(client.check_payment_information_for_app(app_name))
+
+
+def get_active_products(args=None):
+    parser = ArgumentParser(
+        description="""
+Lists all available products.
+
+Example:
+$ ./bin/get_active_products
+[
+  {
+    "code": "JACKAL_S_202301",
+    "name": "Jackal S",
+    "backups_enabled": true,
+    "is_development": false,
+    ...
+  },
+  ...
+]
+""",
+        formatter_class=RawTextHelpFormatter,
+    )
+    parser.parse_args(args=args)
+    client = get_client()
+    print_response(client.get_active_products())

--- a/tests/commands/test_block_attack.py
+++ b/tests/commands/test_block_attack.py
@@ -1,0 +1,54 @@
+from unittest.mock import Mock
+
+from hypernode_api_python.commands import block_attack
+from tests.testcase import TestCase
+
+
+class TestBlockAttack(TestCase):
+    def setUp(self):
+        self.print = self.set_up_patch("hypernode_api_python.commands.print")
+        self.get_client = self.set_up_patch("hypernode_api_python.commands.get_client")
+        self.client = self.get_client.return_value
+        self.get_app_name = self.set_up_patch(
+            "hypernode_api_python.commands.get_app_name"
+        )
+        self.get_app_name.return_value = "myappname"
+        self.client.get_block_attack_descriptions.return_value = Mock(
+            json=lambda: {"BlockSqliBruteForce": "", "BlockDownloaderBruteForce": ""}
+        )
+        self.client.block_attack.return_value = Mock(content="")
+
+    def test_block_attack_gets_client(self):
+        block_attack(["BlockSqliBruteForce"])
+
+        self.get_client.assert_called_once_with()
+
+    def test_block_attack_blocks_attack(self):
+        block_attack(["BlockSqliBruteForce"])
+
+        self.client.block_attack.assert_called_once_with(
+            "myappname", "BlockSqliBruteForce"
+        )
+
+    def test_block_attack_prints_output_on_success(self):
+        block_attack(["BlockSqliBruteForce"])
+
+        self.print.assert_called_once_with(
+            "A job to block the 'BlockSqliBruteForce' attack has been posted."
+        )
+
+    def test_block_attack_prints_output_on_failure(self):
+        self.client.block_attack.return_value = Mock(
+            content='{"attack_name":["\\"BlockDownloaderBruteForce\\" is not a valid choice."]}'
+        )
+
+        block_attack(["BlockDownloaderBruteForce"])
+
+        self.print.assert_called_once_with(
+            '{"attack_name":["\\"BlockDownloaderBruteForce\\" is not a valid choice."]}'
+        )
+
+    def test_block_attack_raises_on_invalid_choice(self):
+        with self.assertRaises(SystemExit):
+            # We get the valid choices from get_block_attack_descriptions
+            block_attack(["DoesNotExist"])

--- a/tests/commands/test_check_payment_information_for_app.py
+++ b/tests/commands/test_check_payment_information_for_app.py
@@ -1,0 +1,39 @@
+from hypernode_api_python.commands import check_payment_information_for_app
+from tests.testcase import TestCase
+
+
+class TestCheckPaymentInformationForApp(TestCase):
+    def setUp(self):
+        self.print_response = self.set_up_patch(
+            "hypernode_api_python.commands.print_response"
+        )
+        self.get_client = self.set_up_patch("hypernode_api_python.commands.get_client")
+        self.client = self.get_client.return_value
+        self.get_app_name = self.set_up_patch(
+            "hypernode_api_python.commands.get_app_name"
+        )
+        self.get_app_name.return_value = "myappname"
+
+    def test_check_payment_information_for_app_gets_client(self):
+        check_payment_information_for_app([])
+
+        self.get_client.assert_called_once_with()
+
+    def test_check_payment_information_for_app_gets_app_name(self):
+        check_payment_information_for_app([])
+
+        self.get_app_name.assert_called_once_with()
+
+    def test_check_payment_information_for_app_gets_current_product_for_app(self):
+        check_payment_information_for_app([])
+
+        self.client.check_payment_information_for_app.assert_called_once_with(
+            "myappname"
+        )
+
+    def test_check_payment_information_for_app_prints_current_product_for_app(self):
+        check_payment_information_for_app([])
+
+        self.print_response.assert_called_once_with(
+            self.client.check_payment_information_for_app.return_value
+        )

--- a/tests/commands/test_check_xgrade.py
+++ b/tests/commands/test_check_xgrade.py
@@ -1,0 +1,37 @@
+from hypernode_api_python.commands import check_xgrade
+from tests.testcase import TestCase
+
+
+class TestCheckXgrade(TestCase):
+    def setUp(self):
+        self.print_response = self.set_up_patch(
+            "hypernode_api_python.commands.print_response"
+        )
+        self.get_client = self.set_up_patch("hypernode_api_python.commands.get_client")
+        self.client = self.get_client.return_value
+        self.get_app_name = self.set_up_patch(
+            "hypernode_api_python.commands.get_app_name"
+        )
+        self.get_app_name.return_value = "myappname"
+
+    def test_check_xgrade_gets_client(self):
+        check_xgrade(["FALCON_S_202203"])
+
+        self.get_client.assert_called_once_with()
+
+    def test_check_xgrade_gets_app_name(self):
+        check_xgrade(["FALCON_S_202203"])
+
+        self.get_app_name.assert_called_once_with()
+
+    def test_check_xgrade_gets_product_info(self):
+        check_xgrade(["FALCON_S_202203"])
+
+        self.client.check_xgrade.assert_called_once_with("myappname", "FALCON_S_202203")
+
+    def test_check_xgrade_prints_product(self):
+        check_xgrade(["FALCON_S_202203"])
+
+        self.print_response.assert_called_once_with(
+            self.client.check_xgrade.return_value
+        )

--- a/tests/commands/test_check_xgrade.py
+++ b/tests/commands/test_check_xgrade.py
@@ -13,6 +13,14 @@ class TestCheckXgrade(TestCase):
             "hypernode_api_python.commands.get_app_name"
         )
         self.get_app_name.return_value = "myappname"
+        self.client.get_active_products.return_value.json.return_value = [
+            {
+                "code": "FALCON_S_202203",
+            },
+            {
+                "code": "JACKAL_M_202201",
+            },
+        ]
 
     def test_check_xgrade_gets_client(self):
         check_xgrade(["FALCON_S_202203"])
@@ -35,3 +43,7 @@ class TestCheckXgrade(TestCase):
         self.print_response.assert_called_once_with(
             self.client.check_xgrade.return_value
         )
+
+    def test_check_xgrade_raises_if_product_not_found(self):
+        with self.assertRaises(SystemExit):
+            check_xgrade(["ProductThatDoesNotExist"])

--- a/tests/commands/test_create_brancher.py
+++ b/tests/commands/test_create_brancher.py
@@ -1,0 +1,40 @@
+from hypernode_api_python.commands import create_brancher
+from tests.testcase import TestCase
+
+
+class TestCreateBrancher(TestCase):
+    def setUp(self):
+        self.print_response = self.set_up_patch(
+            "hypernode_api_python.commands.print_response"
+        )
+        self.get_client = self.set_up_patch("hypernode_api_python.commands.get_client")
+        self.client = self.get_client.return_value
+        self.get_app_name = self.set_up_patch(
+            "hypernode_api_python.commands.get_app_name"
+        )
+        self.get_app_name.return_value = "myappname"
+
+    def test_create_brancher_gets_client(self):
+        create_brancher([])
+
+        self.get_client.assert_called_once_with()
+
+    def test_create_brancher_gets_app_name(self):
+        create_brancher([])
+
+        self.get_app_name.assert_called_once_with()
+
+    def test_create_brancher_creates_brancher(self):
+        create_brancher([])
+
+        expected_data = {}
+        self.client.create_brancher.assert_called_once_with(
+            "myappname", data=expected_data
+        )
+
+    def test_create_brancher_prints_response(self):
+        create_brancher([])
+
+        self.print_response.assert_called_once_with(
+            self.client.create_brancher.return_value
+        )

--- a/tests/commands/test_destroy_brancher.py
+++ b/tests/commands/test_destroy_brancher.py
@@ -1,0 +1,53 @@
+from os import EX_UNAVAILABLE, EX_OK
+
+from hypernode_api_python.commands import destroy_brancher
+from tests.testcase import TestCase
+
+
+class TestDestroyBrancher(TestCase):
+    def setUp(self):
+        self.exit = self.set_up_patch("hypernode_api_python.commands.exit")
+        self.print = self.set_up_patch("hypernode_api_python.commands.print")
+        self.print_response = self.set_up_patch(
+            "hypernode_api_python.commands.print_response"
+        )
+        self.get_client = self.set_up_patch("hypernode_api_python.commands.get_client")
+        self.client = self.get_client.return_value
+
+    def test_destroy_brancher_gets_client(self):
+        destroy_brancher(["myappname-eph1234"])
+
+        self.get_client.assert_called_once_with()
+
+    def test_destroy_brancher_destroys_brancher(self):
+        destroy_brancher(["myappname-eph1234"])
+
+        self.client.destroy_brancher.assert_called_once_with("myappname-eph1234")
+
+    def test_destroy_brancher_prints_app_name_is_valid(self):
+        destroy_brancher(["myappname-eph1234"])
+
+        self.print.assert_called_once_with(
+            "A job has been posted to cancel the 'myappname-eph1234' brancher app."
+        )
+
+    def test_destroy_brancher_prints_app_name_is_invalid(self):
+        self.client.destroy_brancher.side_effect = MemoryError("Killed")
+
+        destroy_brancher(["myappname-eph1234"])
+
+        self.print.assert_called_once_with(
+            "Brancher app 'myappname-eph1234' failed to be cancelled: Killed"
+        )
+
+    def test_destroy_brancher_exits_zero_when_cancel_job_posted(self):
+        destroy_brancher(["myappname-eph1234"])
+
+        self.exit.assert_called_once_with(EX_OK)
+
+    def test_destroy_brancher_exits_nonzero_when_unexpected_exception_occurs(self):
+        self.client.destroy_brancher.side_effect = RuntimeError
+
+        destroy_brancher(["myappname-eph1234"])
+
+        self.exit.assert_called_once_with(EX_UNAVAILABLE)

--- a/tests/commands/test_get_active_branchers.py
+++ b/tests/commands/test_get_active_branchers.py
@@ -1,0 +1,37 @@
+from hypernode_api_python.commands import get_active_branchers
+from tests.testcase import TestCase
+
+
+class TestGetActiveBranchers(TestCase):
+    def setUp(self):
+        self.print_response = self.set_up_patch(
+            "hypernode_api_python.commands.print_response"
+        )
+        self.get_client = self.set_up_patch("hypernode_api_python.commands.get_client")
+        self.client = self.get_client.return_value
+        self.get_app_name = self.set_up_patch(
+            "hypernode_api_python.commands.get_app_name"
+        )
+        self.get_app_name.return_value = "myappname"
+
+    def test_get_active_branchers_gets_client(self):
+        get_active_branchers([])
+
+        self.get_client.assert_called_once_with()
+
+    def test_get_active_branchers_gets_app_name(self):
+        get_active_branchers([])
+
+        self.get_app_name.assert_called_once_with()
+
+    def test_get_active_branchers_gets_active_branchers(self):
+        get_active_branchers([])
+
+        self.client.get_active_branchers.assert_called_once_with("myappname")
+
+    def test_get_active_branchers_prints_active_branchers(self):
+        get_active_branchers([])
+
+        self.print_response.assert_called_once_with(
+            self.client.get_active_branchers.return_value
+        )

--- a/tests/commands/test_get_active_products.py
+++ b/tests/commands/test_get_active_products.py
@@ -1,0 +1,28 @@
+from hypernode_api_python.commands import get_active_products
+from tests.testcase import TestCase
+
+
+class TestGetActiveProducts(TestCase):
+    def setUp(self):
+        self.print_response = self.set_up_patch(
+            "hypernode_api_python.commands.print_response"
+        )
+        self.get_client = self.set_up_patch("hypernode_api_python.commands.get_client")
+        self.client = self.get_client.return_value
+
+    def test_get_active_products_gets_client(self):
+        get_active_products([])
+
+        self.get_client.assert_called_once_with()
+
+    def test_get_active_products_gets_active_products(self):
+        get_active_products([])
+
+        self.client.get_active_products.assert_called_once_with()
+
+    def test_get_active_products_prints_active_products(self):
+        get_active_products([])
+
+        self.print_response.assert_called_once_with(
+            self.client.get_active_products.return_value
+        )

--- a/tests/commands/test_get_app_configurations.py
+++ b/tests/commands/test_get_app_configurations.py
@@ -1,0 +1,28 @@
+from hypernode_api_python.commands import get_app_configurations
+from tests.testcase import TestCase
+
+
+class TestGetAppConfigurations(TestCase):
+    def setUp(self):
+        self.print_response = self.set_up_patch(
+            "hypernode_api_python.commands.print_response"
+        )
+        self.get_client = self.set_up_patch("hypernode_api_python.commands.get_client")
+        self.client = self.get_client.return_value
+
+    def test_get_app_configurations_gets_client(self):
+        get_app_configurations([])
+
+        self.get_client.assert_called_once_with()
+
+    def test_get_app_configurations_gets_slas(self):
+        get_app_configurations([])
+
+        self.client.get_app_configurations.assert_called_once_with()
+
+    def test_get_app_configurations_prints_slas(self):
+        get_app_configurations([])
+
+        self.print_response.assert_called_once_with(
+            self.client.get_app_configurations.return_value
+        )

--- a/tests/commands/test_get_app_flavor.py
+++ b/tests/commands/test_get_app_flavor.py
@@ -1,0 +1,37 @@
+from hypernode_api_python.commands import get_app_flavor
+from tests.testcase import TestCase
+
+
+class TestGetAppFlavor(TestCase):
+    def setUp(self):
+        self.print_response = self.set_up_patch(
+            "hypernode_api_python.commands.print_response"
+        )
+        self.get_client = self.set_up_patch("hypernode_api_python.commands.get_client")
+        self.client = self.get_client.return_value
+        self.get_app_name = self.set_up_patch(
+            "hypernode_api_python.commands.get_app_name"
+        )
+        self.get_app_name.return_value = "myappname"
+
+    def test_get_app_flavor_gets_client(self):
+        get_app_flavor([])
+
+        self.get_client.assert_called_once_with()
+
+    def test_get_app_flavor_gets_app_name(self):
+        get_app_flavor([])
+
+        self.get_app_name.assert_called_once_with()
+
+    def test_get_app_flavor_gets_app_flavor(self):
+        get_app_flavor([])
+
+        self.client.get_app_flavor.assert_called_once_with("myappname")
+
+    def test_get_app_flavor_prints_app_flavor(self):
+        get_app_flavor([])
+
+        self.print_response.assert_called_once_with(
+            self.client.get_app_flavor.return_value
+        )

--- a/tests/commands/test_get_app_info.py
+++ b/tests/commands/test_get_app_info.py
@@ -1,0 +1,37 @@
+from hypernode_api_python.commands import get_app_info
+from tests.testcase import TestCase
+
+
+class TestGetAppInfo(TestCase):
+    def setUp(self):
+        self.print_response = self.set_up_patch(
+            "hypernode_api_python.commands.print_response"
+        )
+        self.get_client = self.set_up_patch("hypernode_api_python.commands.get_client")
+        self.client = self.get_client.return_value
+        self.get_app_name = self.set_up_patch(
+            "hypernode_api_python.commands.get_app_name"
+        )
+        self.get_app_name.return_value = "myappname"
+
+    def test_get_app_info_gets_client(self):
+        get_app_info([])
+
+        self.get_client.assert_called_once_with()
+
+    def test_get_app_info_gets_app_name(self):
+        get_app_info([])
+
+        self.get_app_name.assert_called_once_with()
+
+    def test_get_app_info_gets_app_info(self):
+        get_app_info([])
+
+        self.client.get_app_info_or_404.assert_called_once_with("myappname")
+
+    def test_get_app_info_prints_app_info(self):
+        get_app_info([])
+
+        self.print_response.assert_called_once_with(
+            self.client.get_app_info_or_404.return_value
+        )

--- a/tests/commands/test_get_app_name.py
+++ b/tests/commands/test_get_app_name.py
@@ -1,0 +1,29 @@
+from hypernode_api_python.commands import get_app_name
+from tests.testcase import TestCase
+
+
+class TestGetAppName(TestCase):
+    def setUp(self):
+        self.expected_environment = {
+            "HYPERNODE_APP_NAME": "myappname",
+        }
+        self.set_up_patch(
+            "hypernode_api_python.commands.environ", self.expected_environment
+        )
+
+    def test_get_app_name_returns_app_name(self):
+        ret = get_app_name()
+
+        self.assertEqual(ret, "myappname")
+
+    def test_get_app_name_raises_value_error_if_no_app_name(self):
+        del self.expected_environment["HYPERNODE_APP_NAME"]
+
+        with self.assertRaises(ValueError):
+            get_app_name()
+
+    def test_get_app_name_raises_value_error_if_empty_app_name(self):
+        self.expected_environment["HYPERNODE_APP_NAME"] = ""
+
+        with self.assertRaises(ValueError):
+            get_app_name()

--- a/tests/commands/test_get_available_backups_for_app.py
+++ b/tests/commands/test_get_available_backups_for_app.py
@@ -1,0 +1,37 @@
+from hypernode_api_python.commands import get_available_backups_for_app
+from tests.testcase import TestCase
+
+
+class TestGetAvailableBackupsForApp(TestCase):
+    def setUp(self):
+        self.print_response = self.set_up_patch(
+            "hypernode_api_python.commands.print_response"
+        )
+        self.get_client = self.set_up_patch("hypernode_api_python.commands.get_client")
+        self.client = self.get_client.return_value
+        self.get_app_name = self.set_up_patch(
+            "hypernode_api_python.commands.get_app_name"
+        )
+        self.get_app_name.return_value = "myappname"
+
+    def test_get_available_backups_for_app_gets_client(self):
+        get_available_backups_for_app([])
+
+        self.get_client.assert_called_once_with()
+
+    def test_get_available_backups_for_app_gets_app_name(self):
+        get_available_backups_for_app([])
+
+        self.get_app_name.assert_called_once_with()
+
+    def test_get_available_backups_for_app_gets_available_backups_for_app(self):
+        get_available_backups_for_app([])
+
+        self.client.get_available_backups_for_app.assert_called_once_with("myappname")
+
+    def test_get_available_backups_for_app_prints_available_backups_for_app(self):
+        get_available_backups_for_app([])
+
+        self.print_response.assert_called_once_with(
+            self.client.get_available_backups_for_app.return_value
+        )

--- a/tests/commands/test_get_block_attack_descriptions.py
+++ b/tests/commands/test_get_block_attack_descriptions.py
@@ -1,0 +1,28 @@
+from hypernode_api_python.commands import get_block_attack_descriptions
+from tests.testcase import TestCase
+
+
+class TestGetBlockAttackDescriptions(TestCase):
+    def setUp(self):
+        self.print_response = self.set_up_patch(
+            "hypernode_api_python.commands.print_response"
+        )
+        self.get_client = self.set_up_patch("hypernode_api_python.commands.get_client")
+        self.client = self.get_client.return_value
+
+    def test_get_block_attack_descriptions_gets_client(self):
+        get_block_attack_descriptions([])
+
+        self.get_client.assert_called_once_with()
+
+    def test_get_block_attack_descriptions_gets_slas(self):
+        get_block_attack_descriptions([])
+
+        self.client.get_block_attack_descriptions.assert_called_once_with()
+
+    def test_get_block_attack_descriptions_prints_slas(self):
+        get_block_attack_descriptions([])
+
+        self.print_response.assert_called_once_with(
+            self.client.get_block_attack_descriptions.return_value
+        )

--- a/tests/commands/test_get_client.py
+++ b/tests/commands/test_get_client.py
@@ -1,0 +1,37 @@
+from hypernode_api_python.commands import get_client
+from tests.testcase import TestCase
+
+
+class TestGetClient(TestCase):
+    def setUp(self):
+        self.hypernode_api_python = self.set_up_patch(
+            "hypernode_api_python.commands.HypernodeAPIPython"
+        )
+        self.expected_environment = {
+            "HYPERNODE_API_TOKEN": "mytoken",
+        }
+        self.set_up_patch(
+            "hypernode_api_python.commands.environ", self.expected_environment
+        )
+
+    def test_get_client_instantiates_client(self):
+        get_client()
+
+        self.hypernode_api_python.assert_called_once_with("mytoken")
+
+    def test_get_client_returns_instantiated_client(self):
+        ret = get_client()
+
+        self.assertEqual(ret, self.hypernode_api_python.return_value)
+
+    def test_get_client_raises_value_error_if_no_token(self):
+        del self.expected_environment["HYPERNODE_API_TOKEN"]
+
+        with self.assertRaises(ValueError):
+            get_client()
+
+    def test_get_client_raises_value_error_if_empty_token(self):
+        self.expected_environment["HYPERNODE_API_TOKEN"] = ""
+
+        with self.assertRaises(ValueError):
+            get_client()

--- a/tests/commands/test_get_cluster_relations.py
+++ b/tests/commands/test_get_cluster_relations.py
@@ -1,0 +1,37 @@
+from hypernode_api_python.commands import get_cluster_relations
+from tests.testcase import TestCase
+
+
+class TestGetClusterRelations(TestCase):
+    def setUp(self):
+        self.print_response = self.set_up_patch(
+            "hypernode_api_python.commands.print_response"
+        )
+        self.get_client = self.set_up_patch("hypernode_api_python.commands.get_client")
+        self.client = self.get_client.return_value
+        self.get_app_name = self.set_up_patch(
+            "hypernode_api_python.commands.get_app_name"
+        )
+        self.get_app_name.return_value = "myappname"
+
+    def test_get_cluster_relations_gets_client(self):
+        get_cluster_relations([])
+
+        self.get_client.assert_called_once_with()
+
+    def test_get_cluster_relations_gets_app_name(self):
+        get_cluster_relations([])
+
+        self.get_app_name.assert_called_once_with()
+
+    def test_get_cluster_relations_gets_cluster_relations(self):
+        get_cluster_relations([])
+
+        self.client.get_cluster_relations.assert_called_once_with("myappname")
+
+    def test_get_cluster_relations_prints_cluster_relations(self):
+        get_cluster_relations([])
+
+        self.print_response.assert_called_once_with(
+            self.client.get_cluster_relations.return_value
+        )

--- a/tests/commands/test_get_current_product_for_app.py
+++ b/tests/commands/test_get_current_product_for_app.py
@@ -1,0 +1,37 @@
+from hypernode_api_python.commands import get_current_product_for_app
+from tests.testcase import TestCase
+
+
+class TestGetCurrentProductForApp(TestCase):
+    def setUp(self):
+        self.print_response = self.set_up_patch(
+            "hypernode_api_python.commands.print_response"
+        )
+        self.get_client = self.set_up_patch("hypernode_api_python.commands.get_client")
+        self.client = self.get_client.return_value
+        self.get_app_name = self.set_up_patch(
+            "hypernode_api_python.commands.get_app_name"
+        )
+        self.get_app_name.return_value = "myappname"
+
+    def test_get_current_product_for_app_gets_client(self):
+        get_current_product_for_app([])
+
+        self.get_client.assert_called_once_with()
+
+    def test_get_current_product_for_app_gets_app_name(self):
+        get_current_product_for_app([])
+
+        self.get_app_name.assert_called_once_with()
+
+    def test_get_current_product_for_app_gets_current_product_for_app(self):
+        get_current_product_for_app([])
+
+        self.client.get_current_product_for_app.assert_called_once_with("myappname")
+
+    def test_get_current_product_for_app_prints_current_product_for_app(self):
+        get_current_product_for_app([])
+
+        self.print_response.assert_called_once_with(
+            self.client.get_current_product_for_app.return_value
+        )

--- a/tests/commands/test_get_eav_description.py
+++ b/tests/commands/test_get_eav_description.py
@@ -1,0 +1,28 @@
+from hypernode_api_python.commands import get_eav_description
+from tests.testcase import TestCase
+
+
+class TestGetEavDescription(TestCase):
+    def setUp(self):
+        self.print_response = self.set_up_patch(
+            "hypernode_api_python.commands.print_response"
+        )
+        self.get_client = self.set_up_patch("hypernode_api_python.commands.get_client")
+        self.client = self.get_client.return_value
+
+    def test_get_eav_description_gets_client(self):
+        get_eav_description([])
+
+        self.get_client.assert_called_once_with()
+
+    def test_get_eav_description_gets_slas(self):
+        get_eav_description([])
+
+        self.client.get_app_eav_description.assert_called_once_with()
+
+    def test_get_eav_description_prints_slas(self):
+        get_eav_description([])
+
+        self.print_response.assert_called_once_with(
+            self.client.get_app_eav_description.return_value
+        )

--- a/tests/commands/test_get_flows.py
+++ b/tests/commands/test_get_flows.py
@@ -1,0 +1,35 @@
+from hypernode_api_python.commands import get_flows
+from tests.testcase import TestCase
+
+
+class TestGetFlows(TestCase):
+    def setUp(self):
+        self.print_response = self.set_up_patch(
+            "hypernode_api_python.commands.print_response"
+        )
+        self.get_client = self.set_up_patch("hypernode_api_python.commands.get_client")
+        self.client = self.get_client.return_value
+        self.get_app_name = self.set_up_patch(
+            "hypernode_api_python.commands.get_app_name"
+        )
+        self.get_app_name.return_value = "myappname"
+
+    def test_get_flows_gets_client(self):
+        get_flows([])
+
+        self.get_client.assert_called_once_with()
+
+    def test_get_flows_gets_app_name(self):
+        get_flows([])
+
+        self.get_app_name.assert_called_once_with()
+
+    def test_get_flows_gets_flows(self):
+        get_flows([])
+
+        self.client.get_flows.assert_called_once_with("myappname")
+
+    def test_get_flows_prints_flows(self):
+        get_flows([])
+
+        self.print_response.assert_called_once_with(self.client.get_flows.return_value)

--- a/tests/commands/test_get_next_best_plan.py
+++ b/tests/commands/test_get_next_best_plan.py
@@ -1,0 +1,39 @@
+from hypernode_api_python.commands import get_next_best_plan_for_app
+from tests.testcase import TestCase
+
+
+class TestGetNextBestPlan(TestCase):
+    def setUp(self):
+        self.print_response = self.set_up_patch(
+            "hypernode_api_python.commands.print_response"
+        )
+        self.get_client = self.set_up_patch("hypernode_api_python.commands.get_client")
+        self.client = self.get_client.return_value
+        self.get_app_name = self.set_up_patch(
+            "hypernode_api_python.commands.get_app_name"
+        )
+        self.get_app_name.return_value = "myappname"
+
+    def test_get_next_best_plan_for_app_gets_client(self):
+        get_next_best_plan_for_app([])
+
+        self.get_client.assert_called_once_with()
+
+    def test_get_next_best_plan_for_app_gets_app_name(self):
+        get_next_best_plan_for_app([])
+
+        self.get_app_name.assert_called_once_with()
+
+    def test_get_next_best_plan_for_app_gets_next_best_plan_for_app(self):
+        get_next_best_plan_for_app([])
+
+        self.client.get_next_best_plan_for_app_or_404.assert_called_once_with(
+            "myappname"
+        )
+
+    def test_get_next_best_plan_for_app_prints_next_best_plan_for_app(self):
+        get_next_best_plan_for_app([])
+
+        self.print_response.assert_called_once_with(
+            self.client.get_next_best_plan_for_app_or_404.return_value
+        )

--- a/tests/commands/test_get_product_info.py
+++ b/tests/commands/test_get_product_info.py
@@ -9,6 +9,14 @@ class TestGetProductInfo(TestCase):
         )
         self.get_client = self.set_up_patch("hypernode_api_python.commands.get_client")
         self.client = self.get_client.return_value
+        self.client.get_active_products.return_value.json.return_value = [
+            {
+                "code": "FALCON_S_202203",
+            },
+            {
+                "code": "JACKAL_M_202201",
+            },
+        ]
 
     def test_get_product_info_gets_client(self):
         get_product_info(["FALCON_S_202203"])
@@ -28,3 +36,7 @@ class TestGetProductInfo(TestCase):
         self.print_response.assert_called_once_with(
             self.client.get_product_info_with_price.return_value
         )
+
+    def test_get_product_raises_if_product_not_found(self):
+        with self.assertRaises(SystemExit):
+            get_product_info(["ProductThatDoesNotExist"])

--- a/tests/commands/test_get_product_info.py
+++ b/tests/commands/test_get_product_info.py
@@ -1,0 +1,30 @@
+from hypernode_api_python.commands import get_product_info
+from tests.testcase import TestCase
+
+
+class TestGetProductInfo(TestCase):
+    def setUp(self):
+        self.print_response = self.set_up_patch(
+            "hypernode_api_python.commands.print_response"
+        )
+        self.get_client = self.set_up_patch("hypernode_api_python.commands.get_client")
+        self.client = self.get_client.return_value
+
+    def test_get_product_info_gets_client(self):
+        get_product_info(["FALCON_S_202203"])
+
+        self.get_client.assert_called_once_with()
+
+    def test_get_product_info_gets_product_info_with_price(self):
+        get_product_info(["FALCON_S_202203"])
+
+        self.client.get_product_info_with_price.assert_called_once_with(
+            "FALCON_S_202203"
+        )
+
+    def test_get_product_info_prints_product(self):
+        get_product_info(["FALCON_S_202203"])
+
+        self.print_response.assert_called_once_with(
+            self.client.get_product_info_with_price.return_value
+        )

--- a/tests/commands/test_get_sla.py
+++ b/tests/commands/test_get_sla.py
@@ -1,0 +1,26 @@
+from hypernode_api_python.commands import get_sla
+from tests.testcase import TestCase
+
+
+class TestGetSla(TestCase):
+    def setUp(self):
+        self.print_response = self.set_up_patch(
+            "hypernode_api_python.commands.print_response"
+        )
+        self.get_client = self.set_up_patch("hypernode_api_python.commands.get_client")
+        self.client = self.get_client.return_value
+
+    def test_get_sla_gets_client(self):
+        get_sla(["sla-standard"])
+
+        self.get_client.assert_called_once_with()
+
+    def test_get_sla_gets_sla(self):
+        get_sla(["sla-standard"])
+
+        self.client.get_sla.assert_called_once_with("sla-standard")
+
+    def test_get_sla_prints_sla(self):
+        get_sla(["sla-standard"])
+
+        self.print_response.assert_called_once_with(self.client.get_sla.return_value)

--- a/tests/commands/test_get_slas.py
+++ b/tests/commands/test_get_slas.py
@@ -1,0 +1,26 @@
+from hypernode_api_python.commands import get_slas
+from tests.testcase import TestCase
+
+
+class TestGetSlas(TestCase):
+    def setUp(self):
+        self.print_response = self.set_up_patch(
+            "hypernode_api_python.commands.print_response"
+        )
+        self.get_client = self.set_up_patch("hypernode_api_python.commands.get_client")
+        self.client = self.get_client.return_value
+
+    def test_get_slas_gets_client(self):
+        get_slas([])
+
+        self.get_client.assert_called_once_with()
+
+    def test_get_slas_gets_slas(self):
+        get_slas([])
+
+        self.client.get_slas.assert_called_once_with()
+
+    def test_get_slas_prints_slas(self):
+        get_slas([])
+
+        self.print_response.assert_called_once_with(self.client.get_slas.return_value)

--- a/tests/commands/test_get_whitelist_options.py
+++ b/tests/commands/test_get_whitelist_options.py
@@ -1,0 +1,37 @@
+from hypernode_api_python.commands import get_whitelist_options
+from tests.testcase import TestCase
+
+
+class TestGetWhitelistOptions(TestCase):
+    def setUp(self):
+        self.print_response = self.set_up_patch(
+            "hypernode_api_python.commands.print_response"
+        )
+        self.get_client = self.set_up_patch("hypernode_api_python.commands.get_client")
+        self.client = self.get_client.return_value
+        self.get_app_name = self.set_up_patch(
+            "hypernode_api_python.commands.get_app_name"
+        )
+        self.get_app_name.return_value = "myappname"
+
+    def test_get_whitelist_options_gets_client(self):
+        get_whitelist_options([])
+
+        self.get_client.assert_called_once_with()
+
+    def test_get_whitelist_options_gets_app_name(self):
+        get_whitelist_options([])
+
+        self.get_app_name.assert_called_once_with()
+
+    def test_get_whitelist_options_gets_whitelist_options(self):
+        get_whitelist_options([])
+
+        self.client.get_whitelist_options.assert_called_once_with("myappname")
+
+    def test_get_whitelist_options_prints_whitelist_options(self):
+        get_whitelist_options([])
+
+        self.print_response.assert_called_once_with(
+            self.client.get_whitelist_options.return_value
+        )

--- a/tests/commands/test_get_whitelist_rules.py
+++ b/tests/commands/test_get_whitelist_rules.py
@@ -1,0 +1,37 @@
+from hypernode_api_python.commands import get_whitelist_rules
+from tests.testcase import TestCase
+
+
+class TestGetWhitelistRules(TestCase):
+    def setUp(self):
+        self.print_response = self.set_up_patch(
+            "hypernode_api_python.commands.print_response"
+        )
+        self.get_client = self.set_up_patch("hypernode_api_python.commands.get_client")
+        self.client = self.get_client.return_value
+        self.get_app_name = self.set_up_patch(
+            "hypernode_api_python.commands.get_app_name"
+        )
+        self.get_app_name.return_value = "myappname"
+
+    def test_get_whitelist_rules_gets_client(self):
+        get_whitelist_rules([])
+
+        self.get_client.assert_called_once_with()
+
+    def test_get_whitelist_rules_gets_app_name(self):
+        get_whitelist_rules([])
+
+        self.get_app_name.assert_called_once_with()
+
+    def test_get_whitelist_rules_gets_whitelist_rules(self):
+        get_whitelist_rules([])
+
+        self.client.get_whitelist_rules.assert_called_once_with("myappname")
+
+    def test_get_whitelist_rules_prints_whitelist_rules(self):
+        get_whitelist_rules([])
+
+        self.print_response.assert_called_once_with(
+            self.client.get_whitelist_rules.return_value
+        )

--- a/tests/commands/test_print_response.py
+++ b/tests/commands/test_print_response.py
@@ -1,0 +1,32 @@
+from unittest.mock import Mock
+
+from hypernode_api_python.commands import print_response
+from tests.testcase import TestCase
+
+
+class TestPrintResponse(TestCase):
+    def setUp(self):
+        self.response = Mock()
+        self.response.json.return_value = {
+            "id": 123,
+            "code": "sla-standard",
+            "name": "SLA Standard",
+            "price": 1234,
+            "billing_period": 1,
+            "billing_period_unit": "month",
+        }
+
+        self.print = self.set_up_patch("hypernode_api_python.commands.print")
+
+    def test_print_response_prints_pretty_response(self):
+        print_response(self.response)
+
+        self.print.assert_called_once_with(
+            '{\n  "id": 123,\n  "code": "sla-standard",\n  "name": "SLA Standard",\n  '
+            '"price": 1234,\n  "billing_period": 1,\n  "billing_period_unit": "month"\n}'
+        )
+
+    def test_print_response_returns_none(self):
+        ret = print_response(self.response)
+
+        self.assertIsNone(ret)

--- a/tests/commands/test_validate_app_name.py
+++ b/tests/commands/test_validate_app_name.py
@@ -1,0 +1,55 @@
+from os import EX_UNAVAILABLE, EX_OK
+
+from hypernode_api_python.commands import validate_app_name
+from tests.testcase import TestCase
+
+
+class TestValidateAppName(TestCase):
+    def setUp(self):
+        self.exit = self.set_up_patch("hypernode_api_python.commands.exit")
+        self.print = self.set_up_patch("hypernode_api_python.commands.print")
+        self.print_response = self.set_up_patch(
+            "hypernode_api_python.commands.print_response"
+        )
+        self.get_client = self.set_up_patch("hypernode_api_python.commands.get_client")
+        self.client = self.get_client.return_value
+
+    def test_validate_app_name_gets_client(self):
+        validate_app_name(["myappname"])
+
+        self.get_client.assert_called_once_with()
+
+    def test_validate_app_name_validates_app_name(self):
+        validate_app_name(["myappname"])
+
+        self.client.validate_app_name.assert_called_once_with("myappname")
+
+    def test_validate_app_name_prints_app_name_is_valid(self):
+        validate_app_name(["myappname"])
+
+        self.print.assert_called_once_with("App name 'myappname' is valid.")
+
+    def test_validate_app_name_prints_app_name_is_invalid(self):
+        self.client.validate_app_name.side_effect = RuntimeError(
+            "[\"This value can only contain non-capital letters 'a' through 'z' or digits "
+            '0 through 9."]'
+        )
+
+        validate_app_name(["myappname"])
+
+        self.print.assert_called_once_with(
+            "App name 'myappname' is invalid: [\"This value can only contain non-capital letters "
+            "'a' through 'z' or digits 0 through 9.\"]"
+        )
+
+    def test_validate_app_name_exits_zero_when_valid(self):
+        validate_app_name(["myappname"])
+
+        self.exit.assert_called_once_with(EX_OK)
+
+    def test_validate_app_name_exits_nonzero_when_invalid(self):
+        self.client.validate_app_name.side_effect = RuntimeError
+
+        validate_app_name(["myappname"])
+
+        self.exit.assert_called_once_with(EX_UNAVAILABLE)

--- a/tests/commands/test_xgrade.py
+++ b/tests/commands/test_xgrade.py
@@ -1,0 +1,62 @@
+from unittest.mock import Mock
+
+from hypernode_api_python.commands import xgrade
+from tests.testcase import TestCase
+
+
+class TestXgrade(TestCase):
+    def setUp(self):
+        self.print = self.set_up_patch("hypernode_api_python.commands.print")
+        self.get_client = self.set_up_patch("hypernode_api_python.commands.get_client")
+        self.client = self.get_client.return_value
+        self.get_app_name = self.set_up_patch(
+            "hypernode_api_python.commands.get_app_name"
+        )
+        self.get_app_name.return_value = "myappname"
+        self.client.get_xgrade_descriptions.return_value = Mock(
+            json=lambda: {"FALCON_L_202203": "", "BlockDownloaderBruteForce": ""}
+        )
+        self.client.xgrade.return_value = Mock(content="")
+        self.client.get_active_products.return_value.json.return_value = [
+            {
+                "code": "FALCON_L_202203",
+            },
+            {
+                "code": "FALCON_6XL_202203",
+            },
+        ]
+
+    def test_xgrade_gets_client(self):
+        xgrade(["FALCON_L_202203"])
+
+        self.get_client.assert_called_once_with()
+
+    def test_xgrade_performs_xgrade(self):
+        xgrade(["FALCON_L_202203"])
+
+        self.client.xgrade.assert_called_once_with(
+            "myappname", data={"product": "FALCON_L_202203"}
+        )
+
+    def test_xgrade_prints_output_on_success(self):
+        xgrade(["FALCON_L_202203"])
+
+        self.print.assert_called_once_with(
+            "The job to xgrade Hypernode 'myappname' to product 'FALCON_L_202203' has been posted"
+        )
+
+    def test_xgrade_prints_output_on_failure(self):
+        self.client.xgrade.return_value = Mock(
+            content='{"product":["Object with code=FALCON_6XL_202203 does not exist."]}'
+        )
+
+        xgrade(["FALCON_6XL_202203"])
+
+        self.print.assert_called_once_with(
+            '{"product":["Object with code=FALCON_6XL_202203 does not exist."]}'
+        )
+
+    def test_xgrade_raises_on_invalid_choice(self):
+        with self.assertRaises(SystemExit):
+            # We get the valid choices from get_xgrade_descriptions
+            xgrade(["DoesNotExist"])

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{3.7,3.8,3.9}
+envlist = py{3.7,3.8,3.9,3.10,3.11}
 skipsdist = True
 skip_missing_interpreters = True
 
@@ -9,6 +9,8 @@ basepython =
     py3.7: python3.7
     py3.8: python3.8
     py3.9: python3.9
+    py3.10: python3.10
+    py3.11: python3.11
 
 deps = -rrequirements/development.txt
 


### PR DESCRIPTION
like:
```bash
hypernode-api-python]$ ls bin/
block_attack				get_app_flavor				get_product_info
check_payment_information_for_app	get_app_info				get_sla
check_xgrade				get_available_backups_for_app		get_slas
command					get_block_attack_descriptions		get_whitelist_options
create_brancher				get_cluster_relations			get_whitelist_rules
destroy_brancher			get_current_product_for_app		validate_app_name
get_active_branchers			get_eav_description			xgrade
get_active_products			get_flows
get_app_configurations			get_next_best_plan_for_app

hypernode-api-python]$ ./bin/get_sla --help
usage: get_sla [-h] sla_code

Get a specific SLA.

$ ./bin/get_sla sla-standard
{
  "id": 123,
  "code": "sla-standard",
  "name": "SLA Standard",
  "price": 1234,
  "billing_period": 1,
  "billing_period_unit": "month"
}

positional arguments:
  sla_code    The code of the SLA to get

optional arguments:
  -h, --help  show this help message and exit
```