### PR TITLE
add bin/get_fpm_status

### DIFF
--- a/bin/get_fpm_status
+++ b/bin/get_fpm_status
@@ -1,0 +1,1 @@
+command

--- a/hypernode_api_python/client.py
+++ b/hypernode_api_python/client.py
@@ -21,6 +21,7 @@ HYPERNODE_API_BACKUPS_ENDPOINT = "/v2/app/{}/backup/"
 HYPERNODE_API_BLOCK_ATTACK_ENDPOINT = "/v2/app/{}/block_attack/"
 HYPERNODE_API_BLOCK_ATTACK_DESCRIPTION_ENDPOINT = "/v2/app/block_attack_descriptions/"
 HYPERNODE_API_BRANCHER_APP_ENDPOINT = "/v2/brancher/app/{}/"
+HYPERNODE_API_FPM_STATUS_APP_ENDPOINT = "/v2/nats/{}/hypernode.show-fpm-status"
 HYPERNODE_API_BRANCHER_ENDPOINT = "/v2/brancher/{}/"
 HYPERNODE_API_PRODUCT_APP_DETAIL_ENDPOINT = "/v2/product/app/{}/current/"
 HYPERNODE_API_PRODUCT_LIST_ENDPOINT = "/v2/product/"
@@ -838,6 +839,24 @@ class HypernodeAPIPython:
         """
         return self.requests(
             "GET", HYPERNODE_API_BRANCHER_APP_ENDPOINT.format(app_name)
+        )
+
+    def get_fpm_status(self, app_name):
+        """
+        Get the status of the FPM service for the specified app
+        Example:
+        >    client.get_fpm_status("yourhypernodeappname").json()
+        {
+          "message": null,
+          "data": "50570 IDLE   0.0s -  phpfpm    127.0.0.1       GET  magweb/status.php   (python-requests/2.28.1)\n50571 IDLE   0.0s -  phpfpm    127.0.0.1       GET  magweb/status.php   (python-requests/2.28.1)\n",
+          "status": 200
+        }
+
+        :param str app_name: The name of the Hypernode to get the FPM status for
+        :return obj response: The request response object
+        """
+        return self.requests(
+            "POST", HYPERNODE_API_FPM_STATUS_APP_ENDPOINT.format(app_name)
         )
 
     def create_brancher(self, app_name, data):

--- a/hypernode_api_python/commands.py
+++ b/hypernode_api_python/commands.py
@@ -701,3 +701,24 @@ A job has been posted to cancel the 'yourbrancherappname-eph12345' brancher app.
             )
         )
         exit(EX_UNAVAILABLE)
+
+
+def get_fpm_status(args=None):
+    parser = ArgumentParser(
+        description="""
+Show the status of the PHP-FPM workers.
+
+Example:
+$ ./bin/get_fpm_status
+{
+  "message": null,
+  "data": "50570 IDLE   0.0s -  phpfpm    127.0.0.1       GET  magweb/status.php   (python-requests/2.28.1)\n50571 IDLE   0.0s -  phpfpm    127.0.0.1       GET  magweb/status.php   (python-requests/2.28.1)\n",
+  "status": 200
+}
+""",
+        formatter_class=RawTextHelpFormatter,
+    )
+    parser.parse_args(args=args)
+    client = get_client()
+    app_name = get_app_name()
+    print_response(client.get_fpm_status(app_name))

--- a/tests/client/test_get_fpm_status.py
+++ b/tests/client/test_get_fpm_status.py
@@ -1,0 +1,39 @@
+from unittest import TestCase
+from unittest.mock import Mock
+
+from hypernode_api_python.client import (
+    HypernodeAPIPython,
+    HYPERNODE_API_FPM_STATUS_APP_ENDPOINT,
+)
+
+
+class TestGetFPMStatus(TestCase):
+    def setUp(self):
+        self.client = HypernodeAPIPython(token="my_token")
+        self.mock_request = Mock()
+        self.client.requests = self.mock_request
+        self.app_name = "my_app"
+
+    def test_get_fpm_status_endpoint_is_correct(self):
+        self.assertEqual(
+            "/v2/nats/{}/hypernode.show-fpm-status",
+            HYPERNODE_API_FPM_STATUS_APP_ENDPOINT,
+        )
+
+    def test_calls_fpm_status_endpoint_properly(self):
+        self.client.get_fpm_status(self.app_name)
+
+        self.mock_request.assert_called_once_with(
+            "POST",
+            f"/v2/nats/{self.app_name}/hypernode.show-fpm-status",
+        )
+
+    def test_returns_fpm_status_data(self):
+        response = Mock()
+        response.status_code = 200
+        self.mock_request.return_value = response
+
+        self.assertEqual(
+            self.client.get_fpm_status(self.app_name),
+            self.mock_request.return_value,
+        )

--- a/tests/commands/test_get_fpm_status.py
+++ b/tests/commands/test_get_fpm_status.py
@@ -1,0 +1,32 @@
+from hypernode_api_python.commands import get_fpm_status
+from tests.testcase import TestCase
+
+
+class TestGetFPMStatus(TestCase):
+    def setUp(self):
+        self.print_response = self.set_up_patch(
+            "hypernode_api_python.commands.print_response"
+        )
+        self.get_client = self.set_up_patch("hypernode_api_python.commands.get_client")
+        self.client = self.get_client.return_value
+        self.get_app_name = self.set_up_patch(
+            "hypernode_api_python.commands.get_app_name"
+        )
+        self.get_app_name.return_value = "myappname"
+
+    def test_get_fpm_status_gets_client(self):
+        get_fpm_status([])
+
+        self.get_client.assert_called_once_with()
+
+    def test_get_fpm_status_gets_fpm_status(self):
+        get_fpm_status([])
+
+        self.client.get_fpm_status.assert_called_once_with("myappname")
+
+    def test_get_fpm_status_prints_fpm_status(self):
+        get_fpm_status([])
+
+        self.print_response.assert_called_once_with(
+            self.client.get_fpm_status.return_value
+        )


### PR DESCRIPTION
looks like:
```
hypernode-api-python]$ ./bin/get_fpm_status --help
usage: get_fpm_status [-h]

Show the status of the PHP-FPM workers.

Example:
$ ./bin/get_fpm_status
{
  "message": null,
  "data": "50570 IDLE   0.0s -  phpfpm    127.0.0.1       GET  magweb/status.php   (python-requests/2.28.1)
50571 IDLE   0.0s -  phpfpm    127.0.0.1       GET  magweb/status.php   (python-requests/2.28.1)
",
  "status": 200
}
```

and for nicer output use jq:
```
hypernode-api-python]$ ./bin/get_fpm_status | jq -r .data
181216 GONE   6.9s NL phpfpm    1.2.3.4 GET  hntestakeneosev.hypernode.io/   (curl/7.86.0)
178128 BUSY   4.1s NL phpfpm    1.2.3.4 GET  hntestakeneosev.hypernode.io/   (curl/7.86.0)
181219 BUSY   3.3s NL phpfpm    1.2.3.4 GET  hntestakeneosev.hypernode.io/   (curl/7.86.0)
181456 BUSY   3.0s NL phpfpm    1.2.3.4 GET  hntestakeneosev.hypernode.io/   (curl/7.86.0)
181457 BUSY   2.1s NL phpfpm    1.2.3.4 GET  hntestakeneosev.hypernode.io/   (curl/7.86.0)
181458 BUSY   1.1s NL phpfpm    1.2.3.4 GET  hntestakeneosev.hypernode.io/   (curl/7.86.0)
181461 BUSY   0.1s NL phpfpm    1.2.3.4 GET  hntestakeneosev.hypernode.io/   (curl/7.86.0)
```